### PR TITLE
Add MLX experimental workflow and update training roadmap

### DIFF
--- a/ROADMAP_Implementation.md
+++ b/ROADMAP_Implementation.md
@@ -20,6 +20,7 @@ This roadmap provides a phased approach to implementing the integration between 
 - **File Organization**: All files moved to proper locations and imports updated
 - **Core Modules**: `emotion_production.py`, `drum_humanizer.py`, `dynamics_engine.py` exist and are implemented
 - **Module Structure**: All required directories and `__init__.py` files created
+- **Drum Analysis Config**: `AnalysisConfig` implemented with coverage in `tests/music_brain/test_drum_analysis.py`
 
 ### In Progress 🚧
 - **Reference Updates**: Update any references to moved EDM guide
@@ -235,7 +236,7 @@ This roadmap provides a phased approach to implementing the integration between 
    - [ ] Add `export_as_preset()` method
    - [ ] Add `compare_to_guide()` method
    - [ ] Add `detect_style_from_profile()` method
-   - [ ] Make thresholds configurable (AnalysisConfig)
+   - [x] Make thresholds configurable (AnalysisConfig)
 
 2. Write unit tests
    - [ ] Test preset export
@@ -253,7 +254,7 @@ This roadmap provides a phased approach to implementing the integration between 
 
 **Actions**:
 1. Create configuration system
-   - [ ] Add `AnalysisConfig` to `drum_analysis.py`
+   - [x] Add `AnalysisConfig` to `drum_analysis.py`
    - [ ] Add config loading to `emotion_production.py`
    - [ ] Create JSON config files (optional)
 

--- a/training/mlx_session/README.md
+++ b/training/mlx_session/README.md
@@ -1,0 +1,51 @@
+# 🍎 MLX-Only Workflow (Experimental)
+
+This folder defines a **single-MLX workflow** for running the entire KmiDi model lifecycle on a Mac (M4, 16GB RAM). It is designed as an **experiment** alongside the primary online training vision.
+
+## Goals
+
+- Run **end-to-end training, fine-tuning, and inference** using MLX.
+- Prioritize **M4 Metal performance** with a strict 16GB memory budget.
+- Keep the workflow **self-contained**, so MLX can run the entire project pipeline alone.
+
+## What This Covers
+
+- **Spectocloud** vision model (spectrogram → point cloud)
+- **MIDI generator** (token generation with emotion conditioning)
+- **Lightweight evaluation + export** for on-device inference
+
+## Quick Start (M4 16GB)
+
+```bash
+# 1. Create/activate env
+python3 -m venv venv
+source venv/bin/activate
+
+# 2. Install MLX stack
+pip install mlx mlx-lm numpy scipy librosa pyyaml
+
+# 3. Use the MLX workflow config
+cat training/mlx_session/mlx_workflow.yaml
+
+# 4. Run the MLX workflow runner (create your own wrapper)
+# Example stub command:
+# python scripts/mlx/run_mlx_workflow.py --config training/mlx_session/mlx_workflow.yaml
+```
+
+## Memory-First Settings (16GB)
+
+- **Spectocloud**
+  - batch_size: **4**
+  - grad_accum_steps: **4** (effective batch = 16)
+  - mixed precision: **fp16**
+- **MIDI generator**
+  - batch_size: **6**
+  - sequence length: **512**
+  - gradient checkpointing: **on**
+
+## Notes
+
+- This MLX workflow is intentionally **self-contained** and does **not** rely on the CUDA session.
+- Keep the **online training** path as the primary production vision. MLX is experimental.
+- Use `mlx_workflow.yaml` as the source of truth for resource limits and scheduling.
+

--- a/training/mlx_session/mlx_workflow.yaml
+++ b/training/mlx_session/mlx_workflow.yaml
@@ -1,0 +1,60 @@
+workflow:
+  name: mlx_m4_full_pipeline
+  purpose: "MLX-only experiment for full KmiDi workflow"
+  device_profile: m4_16gb
+
+hardware:
+  device: "Apple M4"
+  memory_gb: 16
+  backend: "mlx"
+  precision: "fp16"
+  max_parallel_jobs: 1
+
+paths:
+  data_root: "data"
+  manifests:
+    spectocloud: "data/manifests/spectocloud.jsonl"
+    midi: "data/manifests/midi.jsonl"
+  checkpoints_root: "checkpoints/mlx"
+  exports_root: "models/mlx"
+
+models:
+  spectocloud:
+    architecture: "swin_tiny_mlx"
+    input:
+      n_mels: 128
+      frames: 64
+    output:
+      point_count: 1200
+    training:
+      batch_size: 4
+      grad_accum_steps: 4
+      learning_rate: 0.0001
+      max_epochs: 20
+      warmup_steps: 1000
+      gradient_checkpointing: true
+  midi_generator:
+    architecture: "transformer_decoder_mlx"
+    vocab_size: 388
+    sequence_length: 512
+    training:
+      batch_size: 6
+      grad_accum_steps: 4
+      learning_rate: 0.0003
+      max_epochs: 15
+      warmup_steps: 500
+      gradient_checkpointing: true
+
+inference:
+  spectocloud:
+    target_latency_ms: 16
+  midi_generator:
+    target_latency_ms_per_token: 5
+
+export:
+  format: ["mlx", "coreml"]
+  quantization: "int8"
+
+notes:
+  - "Keep MLX as experimental path; online training remains primary production vision."
+  - "Use grad_accum_steps to stay within 16GB memory."


### PR DESCRIPTION
### Motivation
- Provide a clear project vision balancing online GPU training with a memory-optimized M4 on-device path for inference and fine-tuning.
- Offer an experimental, self-contained MLX-only workflow to run the full model lifecycle on Apple Silicon (M4, 16GB RAM) without CUDA.
- Make configuration progress visible in the roadmap by marking `AnalysisConfig` support in the drum analysis module.
- Ensure drum/groove test coverage remains green after these documentation and workflow updates.

### Description
- Updated `training/README.md` to document the primary online training vision, an M4 16GB optimization profile, and reference to the MLX experiment.
- Added an MLX experimental folder `training/mlx_session/` containing `README.md` and `mlx_workflow.yaml` with an MLX-focused pipeline and memory-first settings.
- Updated `ROADMAP_Implementation.md` to reflect that `AnalysisConfig` has been implemented and thresholds are configurable in `music_brain/groove/drum_analysis.py`.
- Minor workspace cleanup and created the MLX runbook so a single MLX workflow can be used as an experiment for on-device training/inference.

### Testing
- Ran `pytest tests/music_brain/test_drum_analysis.py tests/music_brain/test_drum_humanizer.py tests/music_brain/test_groove_extractor.py` to validate groove/drum changes.
- Test run result: `72 passed, 1 skipped` and no failures occurred.
- Confirmed imports and new docs do not break the tested modules by running the above test suite successfully.
- No additional automated tests were added in this change; documentation and workflow files were the primary edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a39199f1c8327aa9c0f9904b2de56)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an MLX-only experimental workflow and updates training docs to emphasize online GPU training with an M4 inference path.
> 
> - Adds `training/mlx_session/` with `README.md` and `mlx_workflow.yaml` defining an MLX-focused, 16GB M4 pipeline (training, inference, export)
> - Expands `training/README.md` with online GPU provider options, M4 16GB optimization profile, file structure updates, and MLX reference
> - Updates `ROADMAP_Implementation.md` to mark `AnalysisConfig` implemented and drum analysis thresholds configurable
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ee41045b3f3c31215877b2012c004e4a07653e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->