### PR TITLE
Fix critical bugs found in codebase analysis

### DIFF
--- a/music_brain/metrics.py
+++ b/music_brain/metrics.py
@@ -23,10 +23,10 @@ class TimeMetrics:
     def __enter__(self):
         caller = inspect.stack()[1]
         self.function = str(caller)
-        self.enter_time = time.clock()
+        self.enter_time = time.perf_counter()
 
     def __exit__(self, a, b, c):
-        self.exit_time = time.clock()
+        self.exit_time = time.perf_counter()
         print(
             "It took "
             + str(self.exit_time - self.enter_time)

--- a/music_brain/structure/chord.py
+++ b/music_brain/structure/chord.py
@@ -312,7 +312,9 @@ def detect_chord_from_notes(notes: List[int]) -> Optional[Chord]:
         # Try to match against chord templates
         for quality, template in CHORD_QUALITIES.items():
             template_intervals = tuple(sorted(template))
-            
+            if not template_intervals:
+                continue  # Skip empty templates (defensive)
+
             # Check if intervals match (allowing for octave duplications)
             matches = sum(1 for i in intervals if i in template_intervals)
             coverage = matches / len(template_intervals)

--- a/music_brain/structure/progression.py
+++ b/music_brain/structure/progression.py
@@ -228,8 +228,10 @@ def detect_key_from_progression(chords: List[ParsedChord]) -> Tuple[str, str]:
             weight = 1.5
         
         root_weights[chord.root_num] = root_weights.get(chord.root_num, 0) + weight
-    
-    # Find most weighted root
+
+    # Find most weighted root (fallback to C if no weights)
+    if not root_weights:
+        return ('C', 'major')
     likely_root = max(root_weights, key=root_weights.get)
     
     # Determine mode based on chord qualities at tonic

--- a/music_brain/tier2/lora_finetuner.py
+++ b/music_brain/tier2/lora_finetuner.py
@@ -419,6 +419,11 @@ class MIDIEmotionDataset(Dataset):
     """
 
     def __init__(self, midi_paths: List[str], emotion_paths: List[str], device: str = "cpu"):
+        if len(midi_paths) != len(emotion_paths):
+            raise ValueError(
+                f"midi_paths and emotion_paths must have same length, "
+                f"got {len(midi_paths)} and {len(emotion_paths)}"
+            )
         self.midi_paths = midi_paths
         self.emotion_paths = emotion_paths
         self.device = device


### PR DESCRIPTION
- metrics.py: Replace deprecated time.clock() with time.perf_counter()
- lora_finetuner.py: Add validation that midi_paths and emotion_paths have same length
- chord.py: Add defensive check for empty template_intervals before division
- progression.py: Add fallback for empty root_weights dict in key detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves runtime timing and hardens music analysis/dataset code with defensive checks.
> 
> - Replace deprecated `time.clock()` with `time.perf_counter()` in `music_brain/metrics.py`
> - Add defensive skip for empty `template_intervals` in chord detection (`structure/chord.py`)
> - Add key-detection fallback to `('C', 'major')` when no root weights are present (`structure/progression.py`)
> - Validate equal lengths of `midi_paths` and `emotion_paths` in `MIDIEmotionDataset.__init__` (raises `ValueError`) in `tier2/lora_finetuner.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7826d72dc1442c2fc941b8307362c696daf8165c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->