### PR TITLE
follow-up: wire StateBridge to KellyBrain::generateMidi (first real caller)

### DIFF
--- a/src/engine/KellyBrain.cpp
+++ b/src/engine/KellyBrain.cpp
@@ -16,11 +16,13 @@ using KellyTypesRuleBreakType = RuleBreakType;
 #include "common/Types.h" // Explicit include - this redefines Wound, EmotionNode, etc.
 #include "common/IntentIRAdapter.h"  // IntentFrame support
 #include "engine/IntentPipeline.h" // Full definition needed for std::unique_ptr<IntentPipeline>
+#include "bridge/StateBridge.h"    // For StateBridge emission from generateMidi
 #include "penta/common/RTLogger.h"
 #include <algorithm>
 #include <cctype>
 #include <cmath>
 #include <limits>
+#include <sstream>
 
 namespace kelly {
 
@@ -167,13 +169,20 @@ convertFromLegacyIntentResult(const IntentResult &legacy) {
 
 KellyBrain::KellyBrain()
     : pipeline_(std::make_unique<IntentPipeline>())
-    , midiGenerator_(std::make_unique<MidiGenerator>()) {
-  // IntentPipeline and MidiGenerator are initialized
+    , midiGenerator_(std::make_unique<MidiGenerator>())
+    , stateBridge_(std::make_unique<StateBridge>()) {
+  // IntentPipeline, MidiGenerator, and StateBridge are initialized
 }
 
 bool KellyBrain::initialize(const std::string &dataPath) {
   // The existing IntentPipeline already initializes EmotionThesaurus
   // This could load additional data if needed
+  // Best-effort init for the Python state sync.  If Python isn't available
+  // the bridge disables itself silently; generateMidi() tolerates a nullptr
+  // or disabled bridge.
+  if (stateBridge_) {
+    (void)stateBridge_->initialize();
+  }
   initialized_ = true;
   return true;
 }
@@ -383,6 +392,22 @@ GeneratedMidi KellyBrain::generateMidi(const KellyTypesIntentResult &intent,
   result.mode = intent.mode;
   result.lengthInBeats = static_cast<double>(bars) * 4.0;
   result.bpm = static_cast<float>(intent.tempoBpm);
+
+  // Emit post-generation state to the Python intelligence layer.  Best-effort;
+  // StateBridge::emitStateUpdate is a no-op when Python is unavailable or the
+  // bridge is not initialized.  Not called from the audio thread — generateMidi
+  // is UI/pipeline context, so std::string copies here are fine.
+  if (stateBridge_ && stateBridge_->isAvailable()) {
+    std::ostringstream json;
+    json << "{\"bars\":" << bars
+         << ",\"tempo_bpm\":" << intent.tempoBpm
+         << ",\"key\":\"" << intent.key << "\""
+         << ",\"mode\":\"" << intent.mode << "\""
+         << ",\"num_notes\":" << result.notes.size()
+         << ",\"length_beats\":" << result.lengthInBeats
+         << "}";
+    stateBridge_->emitStateUpdate("midi_generator", json.str());
+  }
 
   return result;
 }

--- a/src/engine/KellyBrain.cpp
+++ b/src/engine/KellyBrain.cpp
@@ -21,10 +21,55 @@ using KellyTypesRuleBreakType = RuleBreakType;
 #include <algorithm>
 #include <cctype>
 #include <cmath>
+#include <cstdio>
 #include <limits>
 #include <sstream>
 
 namespace kelly {
+
+// Escape a string for embedding inside a JSON double-quoted scalar.
+// Handles \" \\ and the C0 control range (\b \f \n \r \t plus \u00XX).
+// Used by emitStateUpdate JSON construction below — values like
+// IntentResult::key/mode are caller-supplied and could contain quotes.
+static std::string jsonEscape(const std::string &s) {
+  std::string out;
+  out.reserve(s.size() + 2);
+  for (unsigned char c : s) {
+    switch (c) {
+    case '"':
+      out += "\\\"";
+      break;
+    case '\\':
+      out += "\\\\";
+      break;
+    case '\b':
+      out += "\\b";
+      break;
+    case '\f':
+      out += "\\f";
+      break;
+    case '\n':
+      out += "\\n";
+      break;
+    case '\r':
+      out += "\\r";
+      break;
+    case '\t':
+      out += "\\t";
+      break;
+    default:
+      if (c < 0x20) {
+        char buf[8];
+        std::snprintf(buf, sizeof(buf), "\\u%04x", c);
+        out += buf;
+      } else {
+        out += static_cast<char>(c);
+      }
+      break;
+    }
+  }
+  return out;
+}
 
 // Helper function to convert EmotionCategory enum to string
 static std::string categoryEnumToString(EmotionCategory cat) {
@@ -401,8 +446,8 @@ GeneratedMidi KellyBrain::generateMidi(const KellyTypesIntentResult &intent,
     std::ostringstream json;
     json << "{\"bars\":" << bars
          << ",\"tempo_bpm\":" << intent.tempoBpm
-         << ",\"key\":\"" << intent.key << "\""
-         << ",\"mode\":\"" << intent.mode << "\""
+         << ",\"key\":\"" << jsonEscape(intent.key) << "\""
+         << ",\"mode\":\"" << jsonEscape(intent.mode) << "\""
          << ",\"num_notes\":" << result.notes.size()
          << ",\"length_beats\":" << result.lengthInBeats
          << "}";

--- a/src/engine/KellyBrain.h
+++ b/src/engine/KellyBrain.h
@@ -27,6 +27,7 @@
 namespace kelly {
 class IntentPipeline;
 class EmotionThesaurus;
+class StateBridge;
 } // namespace kelly
 #include <memory>
 #include <string>
@@ -153,6 +154,9 @@ private:
   // include Types.h) This allows us to keep KellyTypes.h types in the interface
   std::unique_ptr<IntentPipeline> pipeline_;
   std::unique_ptr<MidiGenerator> midiGenerator_;
+  // Python state sync.  Best-effort — null / disabled when Python unavailable.
+  // Forward-declared above so StateBridge.h stays out of this header.
+  std::unique_ptr<StateBridge> stateBridge_;
   bool initialized_ = false;
 
   /**


### PR DESCRIPTION
## Summary

`StateBridge` was previously dead code — class defined, Python-side handlers implemented, zero callers in the C++ tree. The docstring claimed *"Used By: MidiGenerator, MelodyEngine, BassEngine, and other engines"* but grep returns nothing.

This PR makes it real by adding one honest caller:

- `KellyBrain` owns a `std::unique_ptr<StateBridge>` (forward-declared in the header to avoid pulling `<Python.h>` transitively).
- `KellyBrain::initialize()` best-effort starts the bridge (silently disabled if Python unavailable).
- `KellyBrain::generateMidi()` emits a small JSON state after result is populated:
  ```json
  {"bars":8,"tempo_bpm":120,"key":"C","mode":"major","num_notes":42,"length_beats":32.0}
  ```

## Why this shape

- **Non-RT callsite.** `generateMidi` runs on the pipeline/request-handler thread, not the audio callback. The existing `std::string`-carrying `StateUpdate` works here; no fixed-size arena channel needed.
- **If a real RT caller lands later**, it'll shape the RT-safe channel design with concrete requirements instead of speculative infrastructure. The PR #149 docstring for `StateBridge::emitStateUpdate` is already corrected to say "engine/worker threads only" and flag the allocation behavior.
- **Best-effort failure.** `emit_state_update` is `try/except: pass` on the Python side and is only called when `stateBridge_->isAvailable()` returns true. A missing `music_brain` install silently disables the path.

## Stacking

Stacked on `audit/rt-ffi-safety-2026q2` (PR #149). Independent of PR #150 (Wound ODR consolidation).

## Test plan

- [x] `cargo test --manifest-path engine/intent_ir/Cargo.toml` → 9/9
- [ ] `cmake --build build --target KellyCore -j8` on a reviewer machine with JUCE
- [ ] Python smoke: `generateMidi` once, then `get_current_state()` returns the emitted blob
- [ ] Plugin smoke: no crash when Python missing (bridge disables silently)

## Non-scope

- No RT-safe state channel. Build one when a real RT emission site appears.
- No migration of other engines (MelodyEngine, BassEngine, etc.) — those never called `emitStateUpdate` in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new cross-language side effect from `KellyBrain::generateMidi()` to a Python bridge; failures are best-effort but could affect stability if the bridge misbehaves or introduces threading/lifecycle issues.
> 
> **Overview**
> `KellyBrain` now owns and best-effort initializes a `StateBridge`, making Python state sync a real code path.
> 
> After MIDI generation, `generateMidi()` conditionally emits a small JSON state blob (bars/tempo/key/mode/note count/length) to `StateBridge::emitStateUpdate`, including a new `jsonEscape()` helper to safely quote string fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da231c246987b0db970398b0542982eaffeaf1fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->