### PR TITLE
audit: repair BUILD_TESTS target + bound-check WAV reader (debt pack 2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -657,19 +657,14 @@ if(BUILD_TESTS AND BUILD_KELLY_CORE)
     if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/external/Catch2/CMakeLists.txt)
         enable_testing()
         add_subdirectory(external/Catch2 EXCLUDE_FROM_ALL)
-        add_executable(KellyTests
-            tests/cpp/test_emotion_engine.cpp
-            tests/cpp/test_midi_pipeline.cpp
-            tests/cpp/test_chord_diagnostics.cpp
-            tests/cpp/test_ml_pipeline.cpp
-        )
-        target_link_libraries(KellyTests PRIVATE
-            KellyCore
-            Catch2::Catch2WithMain
-        )
         include(CTest)
         include(Catch2)
-        catch_discover_tests(KellyTests)
+        # The previous `KellyTests` target referenced four test files that do
+        # not exist in the tree (test_emotion_engine.cpp, test_midi_pipeline.cpp,
+        # test_chord_diagnostics.cpp, test_ml_pipeline.cpp), silently breaking
+        # `-DBUILD_TESTS=ON`.  Targets below are the tests that actually exist
+        # and compile.  Add a replacement `KellyTests` target here only when
+        # there are real source files to put in it.
         # AudioEmotionRunner tests
         add_executable(AudioEmotionRunnerTests
             tests/cpp/test_audio_emotion_runner.cpp

--- a/src/audio/AudioFile.cpp
+++ b/src/audio/AudioFile.cpp
@@ -58,6 +58,16 @@ bool AudioFile::read(const std::string& filepath) {
         return false;
     }
 
+    // Determine actual file length once so we can bound-check hostile
+    // chunk-size headers below.  A malformed .wav can claim a multi-GB
+    // chunk and trigger OOM when we resize std::vector to totalSamples.
+    file.seekg(0, std::ios::end);
+    const std::streamoff actualFileBytes = file.tellg();
+    file.seekg(0, std::ios::beg);
+    if (actualFileBytes < 44) {
+        return false;  // Smaller than minimum WAV header size
+    }
+
     // Read RIFF header
     char riff[4];
     file.read(riff, 4);
@@ -91,6 +101,13 @@ bool AudioFile::read(const std::string& filepath) {
 
         uint32_t chunkSize;
         file.read(reinterpret_cast<char*>(&chunkSize), sizeof(chunkSize));
+
+        // Bound-check the chunk size against the actual file length before
+        // trusting any seekg(chunkSize, ios::cur) below.  Defeats malformed
+        // files that claim a 4 GB chunk to either OOM us or seek past EOF.
+        if (chunkSize > actualFileBytes) {
+            return false;
+        }
 
         if (std::strncmp(chunkId, "fmt ", 4) == 0) {
             // Read fmt chunk - must be processed first for format info
@@ -134,6 +151,17 @@ bool AudioFile::read(const std::string& filepath) {
     // Now read the data chunk with valid format information
     file.seekg(dataChunkPos);
     header.dataSize = dataChunkSize;
+
+    // Defense against hostile dataSize: cap at the remaining bytes on disk
+    // (dataChunkPos..EOF).  A .wav claiming dataSize = UINT32_MAX would
+    // otherwise allocate ~8 GB (Float32) or ~4 GB (Int16) below.
+    {
+        const std::streamoff remainingBytes = actualFileBytes - static_cast<std::streamoff>(dataChunkPos);
+        if (remainingBytes < 0 ||
+            static_cast<uint64_t>(header.dataSize) > static_cast<uint64_t>(remainingBytes)) {
+            return false;
+        }
+    }
 
     // Set file info using validated format data
     info_.format = AudioFormat::WAV;


### PR DESCRIPTION
## Summary

Two concrete audit items from `docs/CODEAUDIT_CXX_DEEP_2026Q2.md` that survived the RT/FFI pass (PR #149).

### 1. `-DBUILD_TESTS=ON` was silently broken

`CMakeLists.txt` `KellyTests` target referenced four nonexistent files:
```
tests/cpp/test_emotion_engine.cpp
tests/cpp/test_midi_pipeline.cpp
tests/cpp/test_chord_diagnostics.cpp
tests/cpp/test_ml_pipeline.cpp
```
CMake doesn't error on a missing source until build time, so configure succeeded and `-DBUILD_TESTS=ON` appeared to work. Target removed. `AudioEmotionRunnerTests` and `EmotionSchemaTests` still exist and compile.

### 2. WAV reader OOM / DoS on hostile chunk sizes

`src/audio/AudioFile::read()` trusted `chunkSize` and `dataSize` fields from the WAV header without validating against actual file length.

- Line ~117 `file.seekg(chunkSize, ios::cur)` — hostile chunkSize could seek past EOF silently.
- Line ~152 `data_.resize(totalSamples * numChannels)` — malformed `dataSize = UINT32_MAX` → ~8 GB (Float32) / ~4 GB (Int16) allocation → bad_alloc.

Added three defensive bound checks:
1. `actualFileBytes` captured once at entry; reject files under 44 bytes.
2. Each chunkSize rejected if it exceeds `actualFileBytes`.
3. Before sizing the data vector, cap `dataSize` at remaining bytes from the data chunk offset.

## Stacking

Stacked on `audit/rt-ffi-safety-2026q2` (PR #149). Merge #149 first. Independent of #150 and #151.

## Test plan

- [x] `cargo test --manifest-path engine/intent_ir/Cargo.toml` → 9/9 (pre-existing baseline from PR #149 T0)
- [ ] `cmake -S . -B build -DBUILD_TESTS=ON -DBUILD_KELLY_CORE=ON` on a reviewer machine with JUCE — should now configure cleanly (was silently misconfigured before)
- [ ] Feed a crafted WAV with `dataSize = 0xFFFFFFFF` to `AudioFile::read()` — expect `false` return, no allocation

## Non-scope

- Biometric duplicate .cpp/.mm compile target — deferred; needs JUCE available to compile-test the platform-gate CMake change.
- Harmony/groove/osc tri-copy divergence (4/5 + 4/4 + 5/5 files) — biggest remaining root cause per the audit, needs per-pair canonical choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes file-parsing validation and failure behavior in `AudioFile::read()`, which could reject previously-accepted WAVs; build/test changes are low risk but affect CI/dev workflows.
> 
> **Overview**
> Repairs the `-DBUILD_TESTS=ON` configuration by removing the non-building `KellyTests` target that referenced nonexistent test sources, leaving only the test executables that actually exist and are registered via `catch_discover_tests`.
> 
> Hardens `src/audio/AudioFile::read()` by adding file-size and chunk-size bounds checks (minimum header size, per-chunk size sanity, and `dataSize` capped to remaining bytes) to prevent hostile WAV headers from seeking past EOF or triggering large allocations/DoS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3ab5a8f140f8c0963b9a47437ce9d286246399c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->