### PR TITLE
fix(ui): 8 JUCE Component lifetime findings from audit (2026 Q2)

### DIFF
--- a/src/ui/EmotionWorkstation.cpp
+++ b/src/ui/EmotionWorkstation.cpp
@@ -622,10 +622,14 @@ void EmotionWorkstation::setupProjectMenu() {
 void EmotionWorkstation::showProjectMenu() {
   setupProjectMenu();
 
+  // Resolve parent before constructing Options so the getTopLevelComponent()
+  // call happens synchronously on the live `this` and the SafePointer-guarded
+  // lambda below never touches raw `this` again.
+  auto* parent = getTopLevelComponent();
   juce::Component::SafePointer<EmotionWorkstation> safe(this);
   projectMenu_.showMenuAsync(juce::PopupMenu::Options()
                                  .withTargetComponent(&projectMenuButton_)
-                                 .withParentComponent(getTopLevelComponent()),
+                                 .withParentComponent(parent),
                              [safe](int result) {
                                if (auto* self = safe.getComponent()) {
                                  switch (result) {

--- a/src/ui/EmotionWorkstation.cpp
+++ b/src/ui/EmotionWorkstation.cpp
@@ -10,6 +10,11 @@ EmotionWorkstation::EmotionWorkstation(
   setupComponents();
 }
 
+EmotionWorkstation::~EmotionWorkstation() {
+  stopTimer();
+  setLookAndFeel(nullptr);
+}
+
 void EmotionWorkstation::setupComponents() {
   // Apply custom look and feel
   setLookAndFeel(&lookAndFeel_);

--- a/src/ui/EmotionWorkstation.cpp
+++ b/src/ui/EmotionWorkstation.cpp
@@ -617,31 +617,34 @@ void EmotionWorkstation::setupProjectMenu() {
 void EmotionWorkstation::showProjectMenu() {
   setupProjectMenu();
 
+  juce::Component::SafePointer<EmotionWorkstation> safe(this);
   projectMenu_.showMenuAsync(juce::PopupMenu::Options()
                                  .withTargetComponent(&projectMenuButton_)
                                  .withParentComponent(getTopLevelComponent()),
-                             [this](int result) {
-                               switch (result) {
-                               case 1: // New Project
-                                 if (onNewProject) {
-                                   onNewProject();
+                             [safe](int result) {
+                               if (auto* self = safe.getComponent()) {
+                                 switch (result) {
+                                 case 1: // New Project
+                                   if (self->onNewProject) {
+                                     self->onNewProject();
+                                   }
+                                   break;
+                                 case 2: // Open Project
+                                   if (self->onOpenProject) {
+                                     self->onOpenProject();
+                                   }
+                                   break;
+                                 case 3: // Save Project
+                                   if (self->onSaveProject) {
+                                     self->onSaveProject();
+                                   }
+                                   break;
+                                 case 4: // Save Project As
+                                   if (self->onSaveProjectAs) {
+                                     self->onSaveProjectAs();
+                                   }
+                                   break;
                                  }
-                                 break;
-                               case 2: // Open Project
-                                 if (onOpenProject) {
-                                   onOpenProject();
-                                 }
-                                 break;
-                               case 3: // Save Project
-                                 if (onSaveProject) {
-                                   onSaveProject();
-                                 }
-                                 break;
-                               case 4: // Save Project As
-                                 if (onSaveProjectAs) {
-                                   onSaveProjectAs();
-                                 }
-                                 break;
                                }
                              });
 }

--- a/src/ui/EmotionWorkstation.h
+++ b/src/ui/EmotionWorkstation.h
@@ -50,7 +50,7 @@ namespace kelly {
 class EmotionWorkstation : public juce::Component, public juce::Timer {
 public:
   explicit EmotionWorkstation(juce::AudioProcessorValueTreeState &apvts);
-  ~EmotionWorkstation() override = default;
+  ~EmotionWorkstation() override;
 
   void paint(juce::Graphics &g) override;
   void resized() override;

--- a/src/ui/EmotionWorkstation.h
+++ b/src/ui/EmotionWorkstation.h
@@ -103,6 +103,13 @@ private:
   juce::AudioProcessorValueTreeState &apvts_;
 
   // ========================================================================
+  // STYLING — declared first so it outlives all child Components
+  // (C++ destroys members in reverse declaration order; LookAndFeel must be
+  // last to destruct so child repaint callbacks during teardown remain safe).
+  // ========================================================================
+  KellyLookAndFeel lookAndFeel_;
+
+  // ========================================================================
   // WOUND INPUT
   // ========================================================================
   juce::TextEditor woundInput_;
@@ -198,11 +205,6 @@ private:
   GenerateButton generateButton_;
   juce::TextButton previewButton_{"Preview"};
   juce::TextButton exportButton_{"Export to DAW"};
-
-  // ========================================================================
-  // STYLING
-  // ========================================================================
-  KellyLookAndFeel lookAndFeel_;
 
   // ========================================================================
   // HELPER METHODS

--- a/src/ui/LyricDisplay.cpp
+++ b/src/ui/LyricDisplay.cpp
@@ -12,6 +12,10 @@ LyricDisplay::LyricDisplay()
     startTimer(50); // Update at ~20 FPS for smooth highlighting
 }
 
+LyricDisplay::~LyricDisplay() {
+    stopTimer();
+}
+
 void LyricDisplay::paint(juce::Graphics& g) {
     g.fillAll(juce::Colour(0xff1a1a1a)); // Dark background
 

--- a/src/ui/LyricDisplay.h
+++ b/src/ui/LyricDisplay.h
@@ -21,7 +21,7 @@ class LyricDisplay : public juce::Component,
                      public juce::Timer {
 public:
     LyricDisplay();
-    ~LyricDisplay() override = default;
+    ~LyricDisplay() override;
 
     void paint(juce::Graphics& g) override;
     void resized() override;

--- a/src/ui/MusicianCommandPanel.cpp
+++ b/src/ui/MusicianCommandPanel.cpp
@@ -92,6 +92,10 @@ MusicianCommandPanel::MusicianCommandPanel()
     setSize(800, 600);
 }
 
+MusicianCommandPanel::~MusicianCommandPanel() {
+    if (commandInput_) commandInput_->removeListener(this);
+}
+
 //==============================================================================
 // Component Overrides
 //==============================================================================

--- a/src/ui/MusicianCommandPanel.h
+++ b/src/ui/MusicianCommandPanel.h
@@ -38,7 +38,7 @@ class MusicianCommandPanel : public juce::Component
 {
 public:
     MusicianCommandPanel();
-    ~MusicianCommandPanel() override = default;
+    ~MusicianCommandPanel() override;
 
     //==========================================================================
     // Component Overrides

--- a/src/ui/TooltipComponent.cpp
+++ b/src/ui/TooltipComponent.cpp
@@ -5,14 +5,17 @@ namespace kelly {
 
 namespace {
 TooltipComponent& getSharedTooltip() {
-    static TooltipComponent tooltip;
+    // Heap-allocated so juce::DeletedAtShutdown arranges the delete via
+    // juce::MessageManager teardown, preventing a pending callAfterDelay
+    // lambda from accessing a destroyed static-storage object.
+    static TooltipComponent* ptr = new TooltipComponent();
     static bool initialized = false;
     if (!initialized) {
-        tooltip.addToDesktop(juce::ComponentPeer::windowIsTemporary);
-        tooltip.setVisible(false);
+        ptr->addToDesktop(juce::ComponentPeer::windowIsTemporary);
+        ptr->setVisible(false);
         initialized = true;
     }
-    return tooltip;
+    return *ptr;
 }
 } // namespace
 

--- a/src/ui/TooltipComponent.cpp
+++ b/src/ui/TooltipComponent.cpp
@@ -3,21 +3,20 @@
 
 namespace kelly {
 
-namespace {
-TooltipComponent& getSharedTooltip() {
+TooltipComponent* TooltipComponent::sharedInstance_ = nullptr;
+
+TooltipComponent* TooltipComponent::getOrCreateShared() {
     // Heap-allocated so juce::DeletedAtShutdown arranges the delete via
-    // juce::MessageManager teardown, preventing a pending callAfterDelay
-    // lambda from accessing a destroyed static-storage object.
-    static TooltipComponent* ptr = new TooltipComponent();
-    static bool initialized = false;
-    if (!initialized) {
-        ptr->addToDesktop(juce::ComponentPeer::windowIsTemporary);
-        ptr->setVisible(false);
-        initialized = true;
+    // juce::MessageManager teardown. The destructor clears sharedInstance_
+    // so any pending callAfterDelay lambda that fires after shutdown can
+    // null-check the pointer instead of dereferencing freed memory.
+    if (sharedInstance_ == nullptr) {
+        sharedInstance_ = new TooltipComponent();
+        sharedInstance_->addToDesktop(juce::ComponentPeer::windowIsTemporary);
+        sharedInstance_->setVisible(false);
     }
-    return *ptr;
+    return sharedInstance_;
 }
-} // namespace
 
 TooltipComponent::TooltipComponent() {
     setOpaque(false);
@@ -25,12 +24,22 @@ TooltipComponent::TooltipComponent() {
     setInterceptsMouseClicks(false, false);
 }
 
+TooltipComponent::~TooltipComponent() {
+    if (sharedInstance_ == this) {
+        sharedInstance_ = nullptr;
+    }
+}
+
 void TooltipComponent::showTooltip(juce::Component* target, const juce::String& text, int timeoutMs) {
     if (text.isEmpty()) {
         return;
     }
 
-    auto& tooltip = getSharedTooltip();
+    auto* tip = getOrCreateShared();
+    if (tip == nullptr) {
+        return;
+    }
+    auto& tooltip = *tip;
     tooltip.tooltipText_ = text;
 
     const juce::Font font(11.0f);
@@ -58,9 +67,14 @@ void TooltipComponent::showTooltip(juce::Component* target, const juce::String& 
 }
 
 void TooltipComponent::hideTooltip() {
-    auto& tooltip = getSharedTooltip();
-    tooltip.tooltipText_.clear();
-    tooltip.setVisible(false);
+    // After juce::DeletedAtShutdown reaps the singleton (e.g. on app
+    // teardown) any pending callAfterDelay lambda that lands here would
+    // otherwise UAF the freed instance — null-check, do not recreate.
+    if (sharedInstance_ == nullptr) {
+        return;
+    }
+    sharedInstance_->tooltipText_.clear();
+    sharedInstance_->setVisible(false);
 }
 
 void TooltipComponent::paint(juce::Graphics& g) {

--- a/src/ui/TooltipComponent.h
+++ b/src/ui/TooltipComponent.h
@@ -33,7 +33,9 @@ private:
     juce::String tooltipText_;
     juce::Point<int> targetPosition_;
     
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(TooltipComponent)
+    // DeletedAtShutdown base deletes the singleton at MessageManager teardown;
+    // LEAK_DETECTOR would false-positive on that intentional delete, so drop it.
+    JUCE_DECLARE_NON_COPYABLE(TooltipComponent)
 };
 
 /**

--- a/src/ui/TooltipComponent.h
+++ b/src/ui/TooltipComponent.h
@@ -21,20 +21,25 @@ namespace kelly {
 class TooltipComponent : public juce::Component, public juce::DeletedAtShutdown {
 public:
     TooltipComponent();
-    ~TooltipComponent() override = default;
-    
+    ~TooltipComponent() override;
+
     static void showTooltip(juce::Component* target, const juce::String& text, int timeoutMs = 3000);
     static void hideTooltip();
-    
+
     void paint(juce::Graphics& g) override;
     void resized() override;
-    
+
 private:
     juce::String tooltipText_;
     juce::Point<int> targetPosition_;
-    
-    // DeletedAtShutdown base deletes the singleton at MessageManager teardown;
-    // LEAK_DETECTOR would false-positive on that intentional delete, so drop it.
+
+    // The singleton instance is heap-allocated via getOrCreateShared() and
+    // freed by juce::DeletedAtShutdown at MessageManager teardown. The dtor
+    // clears this pointer so any pending callAfterDelay lambda that fires
+    // during shutdown can null-check before dereferencing.
+    static TooltipComponent* sharedInstance_;
+    static TooltipComponent* getOrCreateShared();
+
     JUCE_DECLARE_NON_COPYABLE(TooltipComponent)
 };
 

--- a/src/ui/TooltipComponent.h
+++ b/src/ui/TooltipComponent.h
@@ -18,7 +18,7 @@
 
 namespace kelly {
 
-class TooltipComponent : public juce::Component {
+class TooltipComponent : public juce::Component, public juce::DeletedAtShutdown {
 public:
     TooltipComponent();
     ~TooltipComponent() override = default;

--- a/src/ui/WorkstationPanel.cpp
+++ b/src/ui/WorkstationPanel.cpp
@@ -22,7 +22,9 @@ WorkstationPanel::WorkstationPanel()
     startTimer(30);  // ~30fps
 }
 
-WorkstationPanel::~WorkstationPanel() = default;
+WorkstationPanel::~WorkstationPanel() {
+    stopTimer();
+}
 
 void WorkstationPanel::initializeTracks() {
     tracks_.clear();


### PR DESCRIPTION
## Summary

Applies all 8 findings from `docs/AUDIT_UI_LIFETIME_2026Q2.md` (which lands in PR #153). Four commits organized by severity, plus a review-follow-up.

## Per-finding

### Critical

- **C1 — LyricDisplay stopTimer()** — inherits `juce::Timer`, called `startTimer(50)` in ctor, had `= default` destructor. Timer thread could fire `timerCallback()` on freed memory. Out-of-line dtor now calls `stopTimer()`.

- **C2 — EmotionWorkstation::showProjectMenu SafePointer** — `PopupMenu::showMenuAsync` lambda captured raw `[this]`. If the plugin editor closed while the menu was open, callback fired on destroyed object. Switched to `juce::Component::SafePointer<>` with `getComponent()` null-check; all 4 cases (New/Open/Save/Save As) routed through `self->`. Parent component pre-resolved to a local so `getTopLevelComponent()` doesn't dereference `this` inside the builder chain.

### High

- **H1 — WorkstationPanel stopTimer()** — `juce::Timer` subclass, `startTimer(30)`, dtor `= default`. Fixed.
- **H2 + H4 — EmotionWorkstation stopTimer + setLookAndFeel(nullptr)** — registered LookAndFeel via `setLookAndFeel(&lookAndFeel_)` and started its own timer, dtor `= default`. Fixed with explicit dtor calling both.
- **H3 — MusicianCommandPanel removeListener** — `commandInput_->addListener(this)` in ctor with no matching `removeListener` in dtor. Fixed.

### Medium

- **M1 — EmotionWorkstation member order** — `KellyLookAndFeel lookAndFeel_` was declared LAST among private members (destroys FIRST in reverse declaration order). Moved to first private data member so LookAndFeel outlives all child Components. Belt-and-suspenders alongside the H2 `setLookAndFeel(nullptr)` fix.
- **M2 — TooltipComponent DeletedAtShutdown** — static singleton + pending `callAfterDelay` could race static teardown. Inherit `juce::DeletedAtShutdown`; switch singleton to heap-allocated on first use (base class arranges delete at `MessageManager::deleteInstance()`). Dropped `LEAK_DETECTOR` from the non-copyable macro (would false-positive on the intentional shutdown delete).

## Stacking

Stacked on PR #153 (`audit/cxx-debt-pack-3`) which contains the audit document. Merge #149 → #153 → this.

## Commits (4)

```
9270c3e1  fix(ui): review follow-ups — pre-resolve parent, drop LEAK_DETECTOR on singleton
603cd36d  fix(ui): medium-severity — member order + DeletedAtShutdown
c6ed6c00  fix(ui): high-severity — destructor omissions (H1/H2/H3/H4)
54b1d9f3  fix(ui): critical — LyricDisplay stopTimer + EmotionWorkstation SafePointer (C1/C2)
```

## Test plan

- [x] `cargo test --manifest-path engine/intent_ir/Cargo.toml` → 9/9 (sanity baseline, unrelated to UI)
- [ ] `cmake --build build --target KellyCore -j8` on a reviewer machine with JUCE
- [ ] Smoke: open plugin, open Project popup menu, close editor while menu is open → should NOT crash (was C2 UAF)
- [ ] Smoke: open plugin with Timer-using panels visible, close editor → should NOT fire timer on destroyed object (C1, H1, H2/H4)
- [ ] Smoke: type in command input, close editor mid-focus → should NOT fire listener on destroyed panel (H3)
- [ ] Debug build: no `JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR` false-positive on TooltipComponent

## Files changed

- `src/ui/LyricDisplay.{h,cpp}`
- `src/ui/EmotionWorkstation.{h,cpp}`
- `src/ui/WorkstationPanel.cpp`
- `src/ui/MusicianCommandPanel.{h,cpp}`
- `src/ui/TooltipComponent.{h,cpp}`

## Non-scope

- No changes to UI files without findings (22 files examined, clean).
- Harmony/groove/osc consolidation — still the biggest remaining audit root cause, needs your canonical-tree decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches several JUCE component lifetimes (timers, async menu callbacks, singleton shutdown), which can subtly affect teardown behavior even though changes are targeted at preventing crashes/UAFs.
> 
> **Overview**
> Fixes multiple UI lifetime hazards found in the audit by adding explicit destructors that unregister/stop background activity (e.g., `stopTimer()` in `LyricDisplay`, `WorkstationPanel`, and `EmotionWorkstation`, plus `removeListener()` in `MusicianCommandPanel`).
> 
> Hardens async/UI shutdown paths: `EmotionWorkstation::showProjectMenu()` now uses a `juce::Component::SafePointer` and pre-resolves the parent component to avoid callbacks firing on a destroyed editor, and `TooltipComponent` is converted to a `juce::DeletedAtShutdown` heap-allocated singleton with null-checking to avoid delayed-timer UAF during teardown.
> 
> Also reorders `EmotionWorkstation` members so `KellyLookAndFeel` outlives child components, and clears the LookAndFeel in the destructor (`setLookAndFeel(nullptr)`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3707458d33e2050878e786e1ea4e1eddc8bb939. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->