### PR TITLE
fix(biometric): HealthKit destructor guard mismatch on macOS (leak)

### DIFF
--- a/src/biometric/BiometricInput.mm
+++ b/src/biometric/BiometricInput.mm
@@ -16,8 +16,13 @@ BiometricInput::~BiometricInput() {
     stopStreaming();
   }
 
-  // Clean up bridge instances
-#if HEALTHKIT_AVAILABLE
+  // Clean up bridge instances.
+  // HealthKitBridge.h unconditionally forces HEALTHKIT_AVAILABLE=0 on macOS,
+  // so a `#if HEALTHKIT_AVAILABLE` gate here never fires — even though
+  // initializeHealthKit() below is gated on `JUCE_MAC || JUCE_IOS` and does
+  // allocate a HealthKitBridge.  Align the destructor's gate to the
+  // allocation gate so we release the memory we actually allocate.
+#if JUCE_MAC || JUCE_IOS
   if (healthKitBridge_) {
     delete static_cast<biometric::HealthKitBridge *>(healthKitBridge_);
   }


### PR DESCRIPTION
## Summary

`src/biometric/BiometricInput.mm` had two mismatched preprocessor guards in the same translation unit, causing a silent memory leak on macOS.

## Mechanism

- `initializeHealthKit()` body (line 257): `#if JUCE_MAC || JUCE_IOS` → on macOS, allocates `new biometric::HealthKitBridge()` and stores the pointer in `healthKitBridge_`.
- `~BiometricInput()` delete block (line 20): `#if HEALTHKIT_AVAILABLE` → on macOS, this gate evaluates to **FALSE** because `HealthKitBridge.h:25-27` forces `#define HEALTHKIT_AVAILABLE 0` when `JUCE_MAC` is defined:

```cpp
// HealthKitBridge.h:23-28
#ifdef JUCE_MAC
// HealthKit requires Objective-C++, but we're compiling as C++
// Define a stub interface that can be used from C++ code
// The actual implementation would need to be in a .mm file
#define HEALTHKIT_AVAILABLE 0 // Disable for now to allow C++ compilation
```

So on every macOS build:
- `initializeHealthKit()` allocates
- Destructor never deletes (gate is false)
- One `HealthKitBridge` leaks per `BiometricInput` lifecycle

## Fix

One-line change: destructor's gate → `#if JUCE_MAC || JUCE_IOS`, matching the allocation path.

No change to `BiometricInput.cpp` — that file is the non-Apple path per the CMake platform-gate from PR #149 (commit `caddabbf`); its allocation and delete are both gated on `HEALTHKIT_AVAILABLE && (JUCE_MAC || JUCE_IOS)` which is internally consistent.

## Stacking

Stacked on PR #156 (ODR dedup). Merge order: #149 → #153 → #154 → #155 → #156 → this.

## Test plan

- [x] `cargo test --manifest-path engine/intent_ir/Cargo.toml` → 9/9
- [ ] Reviewer: macOS build with ASan → `BiometricInput::~BiometricInput()` no longer reports unreachable `HealthKitBridge` allocation
- [ ] Reviewer: instantiate + destroy `kelly::BiometricInput`; confirm `HealthKitBridge::~HealthKitBridge()` fires

## Non-scope

- No change to HealthKitBridge.h's forced `#define HEALTHKIT_AVAILABLE 0`. Re-enabling real HealthKit access requires writing `HealthKitBridge.mm` with the Objective-C HealthKit bridge code — separate task (the header already documents the path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a preprocessor-guard change limited to Apple builds to ensure `HealthKitBridge` is deleted; should only affect object lifetime/memory usage.
> 
> **Overview**
> Fixes a macOS/iOS memory leak in `BiometricInput::~BiometricInput()` by changing the HealthKit cleanup preprocessor guard to match the Apple-only allocation path (`#if JUCE_MAC || JUCE_IOS`).
> 
> Also documents why the previous `#if HEALTHKIT_AVAILABLE` gate never ran on macOS, ensuring `HealthKitBridge` instances are consistently freed when `BiometricInput` is destroyed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6765b5f68a97db602f271b6623e9263e11ce7f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->