### PR TITLE
fix(rt,bridge,ffi): four bot review findings on PR #149

### DIFF
--- a/engine/src/engine_rt.cpp
+++ b/engine/src/engine_rt.cpp
@@ -27,9 +27,16 @@ int kmidi_engine_get_state(const kmidi_engine_t* engine,
 
     std::memset(out_state, 0, sizeof(*out_state));
 
-    // Seqlock snapshot (shared helper from RTState.h). Retries up to 8x
-    // on odd sequence or torn window; returns -1 (retry) on exhaustion.
+    // Seqlock snapshot (shared helper from RTState.h). Default retry budget
+    // is 64x; the helper returns false on torn-window exhaustion.
+    //
+    // captured_seq is read inside the lambda so the sequence value matches
+    // the payload — re-reading after the snapshot would race the writer.
+    // (Mirrors src/bridge/kelly_ffi.cpp::kelly_brain_get_rt_state.)
+    uint64_t captured_seq = 0;
     const bool ok = penta::rt_state_snapshot(g_rtState, [&]() noexcept {
+        captured_seq = g_rtState.sequence.load(std::memory_order_relaxed);
+
         out_state->bpm             = g_rtState.bpm.load(std::memory_order_relaxed);
         out_state->sample_position = g_rtState.samplePosition.load(std::memory_order_relaxed);
         out_state->bar             = g_rtState.bar.load(std::memory_order_relaxed);
@@ -51,7 +58,8 @@ int kmidi_engine_get_state(const kmidi_engine_t* engine,
 
     if (!ok) return -1;
 
-    out_state->sequence = g_rtState.sequence.load(std::memory_order_relaxed);
+    // Sequence value captured inside the stable window — coherent with payload.
+    out_state->sequence = captured_seq;
     return 0;
 }
 

--- a/src/bridge/PythonBridgeBase.cpp
+++ b/src/bridge/PythonBridgeBase.cpp
@@ -18,8 +18,12 @@ namespace bridge {
 // the PyThreadState* from PyEval_SaveThread() (cast to void*).
 void* PythonBridgeBase::mainThreadState_ = nullptr;
 
-// Guards first-time PyEval_SaveThread so only one bridge calls it.
-static std::once_flag s_gilReleaseOnce;
+// Single once_flag that wraps Py_Initialize + PyEval_SaveThread together so
+// that the same thread that acquires the GIL via Py_Initialize is also the
+// one that releases it via PyEval_SaveThread. Splitting these across two
+// synchronization points lets thread A initialize (acquiring the GIL) while
+// thread B then races into PyEval_SaveThread without holding it — UB.
+static std::once_flag s_pyStartupOnce;
 
 PythonBridgeBase::PythonBridgeBase(const std::string& bridgeName)
     : BridgeBase(bridgeName)
@@ -49,27 +53,31 @@ bool PythonBridgeBase::isPythonInitialized() {
 // static
 bool PythonBridgeBase::ensurePythonStarted() {
 #ifdef PYTHON_AVAILABLE
-    if (!Py_IsInitialized()) {
-        Py_Initialize();
+    // Both Py_Initialize and PyEval_SaveThread must run on the same thread
+    // and run together — the first half acquires the GIL, the second half
+    // releases it. Wrapping both inside one call_once means exactly one
+    // thread races to do the whole startup; every other thread blocks until
+    // it completes, then sees mainThreadState_ already populated.
+    static std::atomic<bool> startupOk{false};
+    std::call_once(s_pyStartupOnce, []() {
         if (!Py_IsInitialized()) {
-            // Can't call logError (no instance); write to stderr directly.
-            std::cerr << "PythonBridgeBase: Failed to initialize Python interpreter\n";
-            return false;
+            Py_Initialize();
         }
-    }
-    // GIL is held by this thread after Py_Initialize (or was already held if
-    // Python was initialized by a previous caller who hasn't released yet).
-    // Release it exactly once, globally, so all threads can use
-    // PyGILState_Ensure / PyGILGuard safely.
-    std::call_once(s_gilReleaseOnce, []() {
-        // PyEval_InitThreads is a no-op in CPython >=3.9 (always called by
-        // Py_Initialize) but harmless on older versions.
+        if (!Py_IsInitialized()) {
+            std::cerr << "PythonBridgeBase: Failed to initialize Python interpreter\n";
+            return;
+        }
+        // PyEval_InitThreads is a no-op in CPython >=3.9 (Py_Initialize calls
+        // it implicitly) but harmless on older versions.
 #if PY_VERSION_HEX < 0x03090000
         PyEval_InitThreads();
 #endif
+        // Releasing the GIL here is paired with the Py_Initialize above on
+        // the same thread — required by CPython.
         mainThreadState_ = static_cast<void*>(PyEval_SaveThread());
+        startupOk.store(true, std::memory_order_release);
     });
-    return true;
+    return startupOk.load(std::memory_order_acquire);
 #else
     std::cerr << "PythonBridgeBase: Python not available (compiled without PYTHON_AVAILABLE)\n";
     return false;

--- a/src/bridge/kelly_ffi.cpp
+++ b/src/bridge/kelly_ffi.cpp
@@ -332,6 +332,8 @@ const char* kelly_get_error_message(KellyErrorCode error_code) {
             return "Memory allocation failed";
         case KELLY_ERROR_FILE_NOT_FOUND:
             return "File not found";
+        case KELLY_ERROR_AGAIN:
+            return "Transient seqlock contention; retry the call";
         case KELLY_ERROR_UNKNOWN:
         default:
             return "Unknown error";

--- a/src/ml/AudioEmotionRunner.cpp
+++ b/src/ml/AudioEmotionRunner.cpp
@@ -207,14 +207,17 @@ struct AudioEmotionRunnerImpl {
                 if (toPop > 0) {
                     sampleRing.pop(sampleBuffer.data() + samplesAccumulated, toPop);
                     samplesAccumulated += toPop;
-                    // Discard any overflow that didn't fit (ring draining)
+                    // Discard any overflow that didn't fit (ring draining).
+                    // Buffer is local — `static` here would race across
+                    // workerLoop instances when multiple plugins coexist
+                    // in the same process (DAW with multiple inserts).
                     if (avail > toPop) {
                         const size_t overflow = avail - toPop;
-                        // Pop and discard — keep ring from stalling
-                        static float discard[4096];
+                        constexpr size_t kDiscardChunk = 4096;
+                        float discard[kDiscardChunk];
                         size_t remaining = overflow;
                         while (remaining > 0) {
-                            size_t chunk = std::min(remaining, static_cast<size_t>(4096));
+                            const size_t chunk = std::min(remaining, kDiscardChunk);
                             sampleRing.pop(discard, chunk);
                             remaining -= chunk;
                         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addresses the open Bugbot + Codex findings on #149 so the foundation PR can land clean. Stacks **into** `audit/rt-ffi-safety-2026q2` (parent of #149); merge here re-bases the rest of the audit stack on top automatically.

## Findings fixed

| Severity | File | Issue | Source |
|---|---|---|---|
| **HIGH** | `engine/src/engine_rt.cpp:54` | Sequence read outside seqlock window | Bugbot + Codex P2 |
| **MEDIUM** | `src/bridge/PythonBridgeBase.cpp` | `Py_Initialize` and `PyEval_SaveThread` split across two sync points (UB on race) | Bugbot |
| **LOW** | `src/ml/AudioEmotionRunner.cpp:214` | `static float discard[4096]` shared across worker-thread instances (UB) | Bugbot + Codex P1 |
| **P2** | `src/bridge/kelly_ffi.cpp` | `kelly_get_error_message` returns "Unknown error" for new `KELLY_ERROR_AGAIN` | Codex |

## Details

### `engine_rt.cpp` — sequence outside seqlock window

`kmidi_engine_get_state` called `rt_state_snapshot(...)`, then loaded `g_rtState.sequence` *after* the snapshot returned. The writer can advance the seqlock between the helper's `seq2` validation and our post-load, so `out_state->sequence` ends up newer than the payload fields. Mirror the proven pattern from `kelly_brain_get_rt_state` (`src/bridge/kelly_ffi.cpp:884-927`): capture the sequence inside the lambda via `captured_seq`, publish that.

### `PythonBridgeBase.cpp` — `Py_Initialize` + `PyEval_SaveThread` race

Previous logic:
```cpp
if (!Py_IsInitialized()) Py_Initialize();          // outside any sync
std::call_once(s_gilReleaseOnce, []() {
    mainThreadState_ = PyEval_SaveThread();        // could run on different thread
});
```

Race: thread A calls `Py_Initialize()` (acquires the GIL); thread B then wins the `call_once` and calls `PyEval_SaveThread()` *without holding the GIL* — documented CPython UB. Wrap both inside one `call_once` (`s_pyStartupOnce`); use an `std::atomic<bool> startupOk` to surface init failure to subsequent callers without serializing them.

### `AudioEmotionRunner.cpp` — static buffer races across instances

`static float discard[4096]` lives in `workerLoop()`. Two `AudioEmotionRunner` instances (multiple plugin inserts in a DAW) each spawn a worker thread, both call `sampleRing.pop(discard, chunk)` on the same array → unsynchronized concurrent writes. Promote to a stack-local `float discard[kDiscardChunk]`.

### `kelly_get_error_message` — missing `KELLY_ERROR_AGAIN`

PR #149 added `KELLY_ERROR_AGAIN = -7` and made `kelly_brain_get_rt_state` return it on seqlock retry exhaustion, but the message switch falls through to `"Unknown error"`. The header documents retry semantics; expose them in the error string. Add `case KELLY_ERROR_AGAIN: return "Transient seqlock contention; retry the call";`.

## Verification

```
✅ g++ -std=c++17 -fsyntax-only -I engine/include -I include \
     -I third_party/readerwriterqueue engine/src/engine_rt.cpp
✅ g++ -std=c++17 -fsyntax-only -I src -I include -I /usr/include/python3.12 \
     -DPYTHON_AVAILABLE src/bridge/PythonBridgeBase.cpp
✅ g++ -std=c++17 -fsyntax-only -I src -I include \
     -I third_party/concurrentqueue -I third_party/readerwriterqueue \
     src/ml/AudioEmotionRunner.cpp
✅ g++ -std=c++17 -fsyntax-only -I src -I include \
     -I third_party/concurrentqueue -I third_party/readerwriterqueue \
     -I /usr/include/python3.12 src/bridge/kelly_ffi.cpp
```

(Only a benign `-Winterference-size` warning from `RTState.h::kCacheLine`, pre-existing.)

CMake/CTest gate (incl. `RTStateSeqlockTest` regression) still requires `external/JUCE/`, which isn't available in this cloud environment — the seqlock test introduced in #149 is the one that should re-run after this fix lands.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e661d35f-8bcc-4551-9764-b021e45b893f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e661d35f-8bcc-4551-9764-b021e45b893f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

