### PR TITLE
fix(bridge): JSON-escape intent.key/intent.mode in StateBridge emitStateUpdate

### DIFF
--- a/src/engine/KellyBrain.cpp
+++ b/src/engine/KellyBrain.cpp
@@ -21,10 +21,55 @@ using KellyTypesRuleBreakType = RuleBreakType;
 #include <algorithm>
 #include <cctype>
 #include <cmath>
+#include <cstdio>
 #include <limits>
 #include <sstream>
 
 namespace kelly {
+
+// Escape a string for embedding inside a JSON double-quoted scalar.
+// Handles \" \\ and the C0 control range (\b \f \n \r \t plus \u00XX).
+// Used by emitStateUpdate JSON construction below — values like
+// IntentResult::key/mode are caller-supplied and could contain quotes.
+static std::string jsonEscape(const std::string &s) {
+  std::string out;
+  out.reserve(s.size() + 2);
+  for (unsigned char c : s) {
+    switch (c) {
+    case '"':
+      out += "\\\"";
+      break;
+    case '\\':
+      out += "\\\\";
+      break;
+    case '\b':
+      out += "\\b";
+      break;
+    case '\f':
+      out += "\\f";
+      break;
+    case '\n':
+      out += "\\n";
+      break;
+    case '\r':
+      out += "\\r";
+      break;
+    case '\t':
+      out += "\\t";
+      break;
+    default:
+      if (c < 0x20) {
+        char buf[8];
+        std::snprintf(buf, sizeof(buf), "\\u%04x", c);
+        out += buf;
+      } else {
+        out += static_cast<char>(c);
+      }
+      break;
+    }
+  }
+  return out;
+}
 
 // Helper function to convert EmotionCategory enum to string
 static std::string categoryEnumToString(EmotionCategory cat) {
@@ -401,8 +446,8 @@ GeneratedMidi KellyBrain::generateMidi(const KellyTypesIntentResult &intent,
     std::ostringstream json;
     json << "{\"bars\":" << bars
          << ",\"tempo_bpm\":" << intent.tempoBpm
-         << ",\"key\":\"" << intent.key << "\""
-         << ",\"mode\":\"" << intent.mode << "\""
+         << ",\"key\":\"" << jsonEscape(intent.key) << "\""
+         << ",\"mode\":\"" << jsonEscape(intent.mode) << "\""
          << ",\"num_notes\":" << result.notes.size()
          << ",\"length_beats\":" << result.lengthInBeats
          << "}";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bugbot finding (LOW) on PR #151: `KellyBrain::generateMidi` hand-rolls a JSON payload with raw `\"\"` interpolation around `intent.key` and `intent.mode`. A caller-supplied value containing a quote, backslash, or control character produces malformed JSON; the Python `try/except: pass` on the bridge side then drops it silently with no diagnostic.

Stacks **into** `follow-up/state-bridge-wire-real-caller` (#151).

## Fix

Adds a small `jsonEscape()` helper handling `\"`, `\\`, `\b`, `\f`, `\n`, `\r`, `\t` plus `\u00XX` for the rest of the C0 range. Both `intent.key` and `intent.mode` route through it before interpolation.

## Smoke test

```
'C major'      → C major
a"b\\c\nd\te → a\"b\\\\c\\nd\\te
\x01\x1f       → \u0001\u001f
```

(Standard musical strings remain unchanged; defense-in-depth wins.)

Adds `<cstdio>` for `snprintf`. Compiles clean with `g++ -std=c++17 -fsyntax-only`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e661d35f-8bcc-4551-9764-b021e45b893f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e661d35f-8bcc-4551-9764-b021e45b893f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

