### PR TITLE
fix(prrot): add missing &lt;vector&gt; include to SpectralAnalyzer.h

### DIFF
--- a/src/prrot/SpectralAnalyzer.h
+++ b/src/prrot/SpectralAnalyzer.h
@@ -14,6 +14,7 @@
 #include <array>
 #include <cstdint>
 #include <memory>
+#include <vector>
 
 namespace prrot {
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Codex P1 finding on PR #153: `SpectralAnalyzer.h` declares `mutable std::vector<float> fft_scratch_;` but the header does not `#include <vector>`. Any TU that includes this header without already pulling in `<vector>` indirectly fails to compile (`std::vector` not a class template).

Stacks **into** `audit/cxx-debt-pack-3` (#153).

## Fix

One line: `#include <vector>` next to the existing `<array> / <cstdint> / <memory>` block.

## Verification

```
✅ echo '#include "src/prrot/SpectralAnalyzer.h"\nint main(){return 0;}' \
     | g++ -std=c++17 -fsyntax-only -x c++ -I src -I include -
```

The other Bugbot finding on this PR (HealthKit destructor guard) was already addressed by PR #157 in the parent stack — no work needed here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e661d35f-8bcc-4551-9764-b021e45b893f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e661d35f-8bcc-4551-9764-b021e45b893f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

