### PR TITLE
fix(ui): clear TooltipComponent singleton pointer in dtor (UAF)

### DIFF
--- a/src/ui/TooltipComponent.cpp
+++ b/src/ui/TooltipComponent.cpp
@@ -3,21 +3,20 @@
 
 namespace kelly {
 
-namespace {
-TooltipComponent& getSharedTooltip() {
+TooltipComponent* TooltipComponent::sharedInstance_ = nullptr;
+
+TooltipComponent* TooltipComponent::getOrCreateShared() {
     // Heap-allocated so juce::DeletedAtShutdown arranges the delete via
-    // juce::MessageManager teardown, preventing a pending callAfterDelay
-    // lambda from accessing a destroyed static-storage object.
-    static TooltipComponent* ptr = new TooltipComponent();
-    static bool initialized = false;
-    if (!initialized) {
-        ptr->addToDesktop(juce::ComponentPeer::windowIsTemporary);
-        ptr->setVisible(false);
-        initialized = true;
+    // juce::MessageManager teardown. The destructor clears sharedInstance_
+    // so any pending callAfterDelay lambda that fires after shutdown can
+    // null-check the pointer instead of dereferencing freed memory.
+    if (sharedInstance_ == nullptr) {
+        sharedInstance_ = new TooltipComponent();
+        sharedInstance_->addToDesktop(juce::ComponentPeer::windowIsTemporary);
+        sharedInstance_->setVisible(false);
     }
-    return *ptr;
+    return sharedInstance_;
 }
-} // namespace
 
 TooltipComponent::TooltipComponent() {
     setOpaque(false);
@@ -25,12 +24,22 @@ TooltipComponent::TooltipComponent() {
     setInterceptsMouseClicks(false, false);
 }
 
+TooltipComponent::~TooltipComponent() {
+    if (sharedInstance_ == this) {
+        sharedInstance_ = nullptr;
+    }
+}
+
 void TooltipComponent::showTooltip(juce::Component* target, const juce::String& text, int timeoutMs) {
     if (text.isEmpty()) {
         return;
     }
 
-    auto& tooltip = getSharedTooltip();
+    auto* tip = getOrCreateShared();
+    if (tip == nullptr) {
+        return;
+    }
+    auto& tooltip = *tip;
     tooltip.tooltipText_ = text;
 
     const juce::Font font(11.0f);
@@ -58,9 +67,14 @@ void TooltipComponent::showTooltip(juce::Component* target, const juce::String& 
 }
 
 void TooltipComponent::hideTooltip() {
-    auto& tooltip = getSharedTooltip();
-    tooltip.tooltipText_.clear();
-    tooltip.setVisible(false);
+    // After juce::DeletedAtShutdown reaps the singleton (e.g. on app
+    // teardown) any pending callAfterDelay lambda that lands here would
+    // otherwise UAF the freed instance — null-check, do not recreate.
+    if (sharedInstance_ == nullptr) {
+        return;
+    }
+    sharedInstance_->tooltipText_.clear();
+    sharedInstance_->setVisible(false);
 }
 
 void TooltipComponent::paint(juce::Graphics& g) {

--- a/src/ui/TooltipComponent.h
+++ b/src/ui/TooltipComponent.h
@@ -21,20 +21,25 @@ namespace kelly {
 class TooltipComponent : public juce::Component, public juce::DeletedAtShutdown {
 public:
     TooltipComponent();
-    ~TooltipComponent() override = default;
-    
+    ~TooltipComponent() override;
+
     static void showTooltip(juce::Component* target, const juce::String& text, int timeoutMs = 3000);
     static void hideTooltip();
-    
+
     void paint(juce::Graphics& g) override;
     void resized() override;
-    
+
 private:
     juce::String tooltipText_;
     juce::Point<int> targetPosition_;
-    
-    // DeletedAtShutdown base deletes the singleton at MessageManager teardown;
-    // LEAK_DETECTOR would false-positive on that intentional delete, so drop it.
+
+    // The singleton instance is heap-allocated via getOrCreateShared() and
+    // freed by juce::DeletedAtShutdown at MessageManager teardown. The dtor
+    // clears this pointer so any pending callAfterDelay lambda that fires
+    // during shutdown can null-check before dereferencing.
+    static TooltipComponent* sharedInstance_;
+    static TooltipComponent* getOrCreateShared();
+
     JUCE_DECLARE_NON_COPYABLE(TooltipComponent)
 };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bugbot finding (MEDIUM) on PR #154: the function-local `static TooltipComponent* ptr = new TooltipComponent()` in `getSharedTooltip()` is never reset when `juce::DeletedAtShutdown::deleteAll()` reaps the heap object during shutdown. A pending `juce::Timer::callAfterDelay` lambda firing post-teardown would dereference `*ptr` (freed) via `hideTooltip()` — use-after-free.

Stacks **into** `audit/ui-lifetime-fixes-2026q2` (#154).

## Fix

Switch to the canonical JUCE `DeletedAtShutdown` singleton pattern:

- Promote the pointer to a class-level static `TooltipComponent::sharedInstance_`.
- Out-of-line dtor nulls the pointer when `this == sharedInstance_`.
- `hideTooltip()` early-returns on null (post-shutdown timer fires no-op instead of UAF).
- `showTooltip()` goes through `getOrCreateShared()` so re-entry during normal app lifetime still works.

Net: same singleton semantics, no UAF window during shutdown.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e661d35f-8bcc-4551-9764-b021e45b893f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e661d35f-8bcc-4551-9764-b021e45b893f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

