### PR TITLE
fix(build): unblock the integration gate after the 2026Q2 audit stack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -589,7 +589,22 @@ if(BUILD_KELLY_FFI AND BUILD_KELLY_CORE)
             INSTALL_NAME_DIR "@rpath"
         )
     endif()
-    
+
+    # Sanitizer flag propagation: KellyCore's .o files are ASan/UBSan/TSan
+    # instrumented when those options are set, but the dylib link step must
+    # also link the sanitizer runtime — otherwise the link fails with
+    # ___asan_*/__ubsan_*/__tsan_* undefined symbols. This block has to live
+    # AFTER add_library(KellyFFI ...) because the earlier ASan/TSan block
+    # (~line 396) runs before the KellyFFI target exists.
+    if(KMIDI_ENABLE_ASAN)
+        enable_sanitizers(KellyFFI)
+        message(STATUS "KellyFFI: ASan + UBSan enabled")
+    endif()
+    if(KMIDI_ENABLE_TSAN)
+        enable_thread_sanitizer(KellyFFI)
+        message(STATUS "KellyFFI: ThreadSanitizer enabled")
+    endif()
+
     # Install FFI library
     install(TARGETS KellyFFI
         RUNTIME DESTINATION bin
@@ -632,8 +647,11 @@ endif()
 
 # Tests
 if(BUILD_TESTS AND BUILD_KELLY_CORE)
+    # enable_testing() must run unconditionally so that the standalone
+    # RTStateSeqlockTest and SIMDKernelsTest add_test() calls below
+    # register with ctest even when Catch2 isn't present.
+    enable_testing()
     if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/external/Catch2/CMakeLists.txt)
-        enable_testing()
         add_subdirectory(external/Catch2 EXCLUDE_FROM_ALL)
         add_executable(KellyTests
             tests/cpp/test_emotion_engine.cpp

--- a/libs/daiw/CMakeLists.txt
+++ b/libs/daiw/CMakeLists.txt
@@ -1,50 +1,35 @@
-# daiw_core — RT-safe music primitives (standalone internal library)
+# daiw_core — RT-safe music primitives (interface-only after 2026 Q2 audit)
 #
-# The daiw namespace provides low-level types and utilities used by
-# both penta (RT engines) and kelly (intelligence layer).
-# Dependency chain: daiw → penta → kelly
+# The daiw namespace originally exposed low-level audio_buffer / simd_ops /
+# midi_engine / chord / progression / AudioFile / etc. as separate .cpp
+# translation units inside this static library. Per docs/AUDIT_DEAD_CODE_2026Q2.md
+# all of those .cpp files were verified dead and deleted in PRs #159/#160:
+#   - DSP primitives migrated into include/penta/common/SIMDKernels.h
+#   - core/midi/harmony stubs had zero callers
+#   - audio/export/project sources were never compiled into KellyCore (already
+#     CMake-EXCLUDE_REGEX'd in root CMakeLists.txt)
 #
-# Source files remain in their original directories under src/ but are
-# excluded from KellyCore's GLOB_RECURSE and compiled here instead.
+# What remained: a propagation layer for the JUCE link interface and the
+# common include paths. Convert to INTERFACE so consumers (KellyCore) keep
+# the same PUBLIC linkage of include dirs + JUCE without trying to compile
+# nonexistent sources.
+#
+# Dependency chain: daiw → penta → kelly  (preserved; just header-only now)
 
-add_library(daiw_core STATIC
-    # DSP primitives
-    ${CMAKE_SOURCE_DIR}/src/dsp/audio_buffer.cpp
-    ${CMAKE_SOURCE_DIR}/src/dsp/simd_ops.cpp
-    ${CMAKE_SOURCE_DIR}/src/dsp/dsp.cpp
-    # Core utilities
-    ${CMAKE_SOURCE_DIR}/src/core/memory.cpp
-    ${CMAKE_SOURCE_DIR}/src/core/logging.cpp
-    ${CMAKE_SOURCE_DIR}/src/core/types.cpp
-    # MIDI primitives
-    ${CMAKE_SOURCE_DIR}/src/midi/midi_engine.cpp
-    ${CMAKE_SOURCE_DIR}/src/midi/MidiIO.cpp
-    ${CMAKE_SOURCE_DIR}/src/midi/MidiMessage.cpp
-    ${CMAKE_SOURCE_DIR}/src/midi/MidiSequence.cpp
-    # Harmony primitives
-    ${CMAKE_SOURCE_DIR}/src/harmony/chord.cpp
-    ${CMAKE_SOURCE_DIR}/src/harmony/progression.cpp
-    # Audio I/O
-    ${CMAKE_SOURCE_DIR}/src/audio/AudioFile.cpp
-    # Export
-    ${CMAKE_SOURCE_DIR}/src/export/StemExporter.cpp
-    # Project
-    ${CMAKE_SOURCE_DIR}/src/project/ProjectFile.cpp
-)
+add_library(daiw_core INTERFACE)
 
-target_include_directories(daiw_core PUBLIC
+target_include_directories(daiw_core INTERFACE
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/src
 )
 
-# daiw uses JUCE for audio I/O, file handling, and DSP
-target_link_libraries(daiw_core PUBLIC
+# daiw still re-exports JUCE for audio I/O / file handling / DSP types
+# consumed via headers (juce::AudioBuffer, juce::AudioFormatManager, etc.).
+target_link_libraries(daiw_core INTERFACE
     juce::juce_core
     juce::juce_audio_basics
     juce::juce_audio_formats
 )
 
-set_target_properties(daiw_core PROPERTIES
-    CXX_STANDARD 20
-    CXX_STANDARD_REQUIRED ON
-)
+# INTERFACE targets don't take CXX_STANDARD properties — the consumers
+# (KellyCore) already enforce C++20.


### PR DESCRIPTION
Three pre-existing CMake bugs that prevent the [`AGENTS.md` integration gate](https://github.com/sburdges-eng/KmiDi/blob/main/AGENTS.md#integration-gate-merge-checklist) from running on the post-audit-stack tree. Without this, `cmake -S . -B build -DBUILD_KELLY_CORE=ON` **fails to configure** on the merged stack — anyone trying to validate `KMIDI_ENABLE_ASAN=ON` or run `RTStateSeqlockTest` is blocked.

Targets `audit/regression-guards` (top of the audit stack), so it lands once with the rest of the cleanup work.

## Three bugs, three fixes

### 1. Sanitizer flags never reach \`KellyFFI\` (configure-time ordering)

The \`if(KMIDI_ENABLE_ASAN)\` block at line ~396 calls \`enable_sanitizers(KellyCore)\`, but \`KellyFFI\` is defined later at line ~581. Result: \`KellyCore\`'s \`.o\` files arrive at the dylib link step ASan-instrumented, but \`KellyFFI\` itself never gets \`-fsanitize=address\` on its link line — fails with hundreds of \`___asan_*\` undefined symbols. Same for TSan.

**Fix**: move the per-target sanitizer enable for \`KellyFFI\` to right after \`add_library(KellyFFI ...)\` so \`TARGET KellyFFI\` exists when the if checks fire.

### 2. \`enable_testing()\` gated on Catch2 — standalone ctests don't register

\`RTStateSeqlockTest\` and \`SIMDKernelsTest\` (added in #149, no Catch2 dependency) call \`add_test()\` unconditionally, but \`enable_testing()\` lives inside the Catch2 \`if(EXISTS …)\` block. Without Catch2 vendored locally, \`ctest --test-dir build\` reports \`No tests were found!!!\` — the new seqlock regression test from #149 silently doesn't run.

**Fix**: hoist \`enable_testing()\` above the Catch2 gate.

### 3. \`daiw_core\` references files PR #159 deleted (real shipping blocker)

\`\`\`
CMake Error at libs/daiw/CMakeLists.txt:10 (add_library):
  Cannot find source file:
    /Users/seanburdges/Dev/KmiDi/src/dsp/audio_buffer.cpp
\`\`\`

PR #159 (\`chore(cleanup): delete 12 definite-dead source files\`) deleted **every single source** that \`libs/daiw/CMakeLists.txt:10\` references — 15 files: 3 dsp + 3 core + 4 midi + 2 harmony + audio/export/project. The audit doc explicitly noted these were *\"migrated to \`include/penta/common/SIMDKernels.h\`\"*. But the deletion commit didn't update the CMake — so once the dead-code stack is merged, \`BUILD_KELLY_CORE=ON\` fails to configure.

**Fix**: convert \`daiw_core\` from \`STATIC\` (15 sources, all gone) to \`INTERFACE\` (header-only). Continues to propagate the JUCE link interface (\`juce::juce_core\`, \`juce::juce_audio_basics\`, \`juce::juce_audio_formats\`) and include paths to \`KellyCore\` — consumer-side semantics unchanged — without trying to compile zero translation units. Drops \`set_target_properties(daiw_core CXX_STANDARD 20)\` (INTERFACE targets reject it; \`KellyCore\` already enforces C++20).

This is the same fix orphan branch \`cursor/daiw-core-cmake-sources-465f\` was attempting; that branch has additional churn and can be closed in favor of this one.

## Verification

Verified locally on macOS arm64 (Apple clang 21, cmake 4.3.1, ninja 1.13.2):

\`\`\`bash
✅ cmake -S . -B build-verify -G Ninja \\
   -DCMAKE_BUILD_TYPE=Release \\
   -DBUILD_KELLY_CORE=ON -DBUILD_KELLY_FFI=ON -DBUILD_TESTS=ON
   → Configuring done; Generating done; build files written.

✅ cmake --build build-verify --target RTStateSeqlockTest SIMDKernelsTest -j8
   → 4/4 objects built clean.

✅ ctest --test-dir build-verify --output-on-failure
   → 100% tests passed, 0 tests failed out of 2
     RTStateSeqlockTest:  1M iters, 0 tearings, 0 pre-publish reads
     SIMDKernelsTest:     14-size NEON/AVX2/scalar parity, all match
\`\`\`

ASan + UBSan, full build:

\`\`\`bash
✅ cmake -S . -B build-asan -G Ninja \\
   -DCMAKE_BUILD_TYPE=Debug \\
   -DBUILD_KELLY_CORE=ON -DBUILD_KELLY_FFI=ON -DBUILD_TESTS=ON \\
   -DKMIDI_ENABLE_ASAN=ON
   → 'KellyCore: ASan + UBSan enabled'
     'KellyFFI:  ASan + UBSan enabled'

✅ cmake --build build-asan --target KellyCore KellyFFI -j8
   → 245 objects, dylib linked clean (no undefined sanitizer symbols).

✅ ASAN_OPTIONS=halt_on_error=1 ./build-asan/RTStateSeqlockTest
   → 1M iters, 0 tearings, 0 pre-publish, ASan + UBSan clean.

✅ Smoke-loaded the ASan-instrumented libKellyFFI.dylib in a tiny consumer:
   kelly_get_error_message(KELLY_SUCCESS):       Success
   kelly_get_error_message(KELLY_ERROR_AGAIN):   Transient seqlock contention; retry the call
   kelly_get_error_message(KELLY_ERROR_UNKNOWN): Unknown error
   (KELLY_ERROR_AGAIN message is the new branch added by PR #162.)
\`\`\`

TSan, seqlock torture only:

\`\`\`bash
✅ cmake -S . -B build-tsan -G Ninja \\
   -DCMAKE_BUILD_TYPE=Debug \\
   -DBUILD_KELLY_CORE=ON -DBUILD_TESTS=ON -DKMIDI_ENABLE_TSAN=ON

✅ TSAN_OPTIONS=halt_on_error=1 ./build-tsan/RTStateSeqlockTest
   → 1M iters, 0 tearings, zero data-race reports.
\`\`\`

\`cargo test --manifest-path engine/intent_ir/Cargo.toml\`:

\`\`\`
✅ 9/9 passed (cargo 1.94.1, no edition2024 issue any longer).
\`\`\`

\`pytest tests/unit/\`:

\`\`\`
✅ 270 passed, 35 skipped, 4 pre-existing failures present on \`main\` already
   (test_spectocloud_rejects_*, test_emotion_rust_exists_after_sync,
    test_intent_frame_rust_exists_after_sync — not regressions, tracked
    elsewhere).
\`\`\`

## Why this is the right base branch

\`audit/regression-guards\` is the top of the audit stack. This fix is conceptually a follow-up to PR #159's dead-code sweep — that PR created the breakage; this one closes it. Stacking here means the stack lands in one consistent state.

## Note on PR #165

The full Release build of \`KellyCore\` also needs PR #165's \`<vector>\` include in \`SpectralAnalyzer.h\` to complete (verified independently — adding that one-liner makes the full \`cmake --build\` succeed). #165 stacks under #153, this PR under #161; both will be on \`main\` once the audit stack lands.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Build-system changes affect sanitizer linkage, test discovery, and how `daiw_core` links/propagates JUCE; misconfiguration could break builds or alter link interfaces across targets.
> 
> **Overview**
> Unblocks post-audit builds by fixing three CMake integration issues: `KellyFFI` now receives ASan/UBSan/TSan link flags when enabled, and `enable_testing()` is run unconditionally so standalone `add_test()` registrations work even without vendored Catch2.
> 
> Converts `daiw_core` from a `STATIC` library with deleted sources into an `INTERFACE` target that only propagates include paths and JUCE dependencies, preventing configure-time failures while keeping consumer linkage semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61c752be946e8d82a173992c1236ffdb71f258f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->