### PR TITLE
fix(ci): declare .worktrees/integration-finalize submodule in .gitmod…

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,9 @@
 [submodule "external/JUCE"]
 	path = external/JUCE
 	url = https://github.com/juce-framework/JUCE.git
+
+[submodule ".worktrees/integration-finalize"]
+	path = .worktrees/integration-finalize
+	url = ./
+	branch = feature/integration-finalize
+	ignore = all


### PR DESCRIPTION
…ules

CI's actions/checkout@v4 with `submodules: recursive` was fatal'ing on every job (ubuntu/macos/windows × debug/release) with:

  fatal: No url found for submodule path '.worktrees/integration-finalize'
         in .gitmodules

HEAD has been pinning a 160000-mode gitlink at .worktrees/integration-finalize since before #147, but .gitmodules only declared external/JUCE — so CI recursive checkout had no URL to resolve the gitlink against.

Add the missing block, using a relative URL ('./') so the submodule resolves to the same superproject remote. The feature/integration-finalize branch was pushed to origin so the pinned commit (56a94572) is reachable.

ignore = all matches the existing pattern (this directory is an active local worktree that's expected to drift from the pinned commit; we don't want it polluting git status).

## Summary

<!-- Briefly describe what this PR does and why. -->

## Changes

<!-- List the key changes made in this PR. -->

- 

## Review Checklist

### Author

- [ ] Code follows existing project conventions (see `docs/NAMING_CONVENTIONS.md`)
- [ ] Tests added or updated for changed behaviour
- [ ] No new lint or type-check warnings introduced
- [ ] Documentation updated where applicable
- [ ] No secrets, credentials, or absolute paths committed
- [ ] RT-safety rules preserved (no heap allocations on audio thread)

### Reviewer

- [ ] Logic is correct and handles edge cases
- [ ] No security or input-validation regressions
- [ ] CI checks pass (Python tests, C++ build, lint, formatting)
- [ ] Changes are minimal and focused on the stated goal

## Testing

<!-- Describe how you verified the changes (e.g., ran tests, manual steps). -->

```
pytest tests/unit/ -v
```

## Related Issues

<!-- Link any related issues, e.g., Fixes #123. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates `.gitmodules` metadata to satisfy recursive submodule checkout in CI, with no runtime code changes.
> 
> **Overview**
> Fixes CI failures with `submodules: recursive` by adding a missing `.gitmodules` entry for the `.worktrees/integration-finalize` gitlink. The new submodule uses a relative `url = ./`, pins to the `feature/integration-finalize` branch, and sets `ignore = all` to avoid local worktree drift showing up in `git status`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1018227c4c3df4e6579fa075f90c28e8951ed064. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->