### PR TITLE
fix(ci): wire dev-base-template workflow to actual repo layout

### DIFF
--- a/.github/workflows/dev-base-template.yml
+++ b/.github/workflows/dev-base-template.yml
@@ -64,8 +64,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - name: Init JUCE submodule
+        # Selective init — only external/JUCE, not all submodules. Avoids
+        # tying cpp-ctest to the health of .worktrees/integration-finalize
+        # (the local-worktree gitlink) which is not a build dependency.
+        run: git submodule update --init --depth 1 external/JUCE
       - name: Install build deps
         run: |
           sudo apt-get update
@@ -97,9 +100,11 @@ jobs:
           node-version: "18"
       - name: Install web deps
         run: npm install --ignore-scripts
-      - name: Lint/Smoke
-        run: |
-          npm test -- --watch=false || true
+      - name: Smoke (typecheck + build)
+        # Root package.json has no `test` script — `npm test || true` would
+        # silently pass without exercising anything. `npm run build` runs
+        # `tsc && vite build`, which catches TS regressions and bundle errors.
+        run: npm run build
 
 # Notes:
 # - This is a staging-friendly template anchored to the KMIDI_STRUCTURE_PLAN.md layout.

--- a/.github/workflows/dev-base-template.yml
+++ b/.github/workflows/dev-base-template.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
       - name: Install web deps
         run: npm install --ignore-scripts
       - name: Smoke (typecheck + build)

--- a/.github/workflows/dev-base-template.yml
+++ b/.github/workflows/dev-base-template.yml
@@ -64,10 +64,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Install build deps
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build g++
+          sudo apt-get install -y cmake ninja-build g++ qt6-base-dev
       - name: Configure
         run: |
           cmake -S . -B build -G Ninja
@@ -94,10 +96,8 @@ jobs:
         with:
           node-version: "18"
       - name: Install web deps
-        working-directory: web
         run: npm install --ignore-scripts
       - name: Lint/Smoke
-        working-directory: web
         run: |
           npm test -- --watch=false || true
 


### PR DESCRIPTION
## Summary

The `dev-base-template` workflow has been failing every push/PR for ages because it was copy-pasted from some external template and never adapted to KmiDi's actual layout. Three small fixes in the workflow file alone:

### 1. `cpp-ctest` — missing `submodules: recursive`

`actions/checkout@v4` was called without submodule options, so `external/JUCE` was never cloned. Configure then failed reading `external/JUCE/CMakeLists.txt`.

### 2. `cpp-ctest` — missing Qt6

Apt install only had `cmake ninja-build g++`, but the repo root `CMakeLists.txt:111` hits:

```cmake
find_package(Qt6 COMPONENTS Core Widgets REQUIRED)
```

whenever `BUILD_KELLY_CORE` / `BUILD_DESKTOP` / `BUILD_PLUGINS` is on (default). Added `qt6-base-dev` to the apt install.

### 3. `frontend-smoke` — `working-directory: web` doesn't exist

There's no `web/` directory in the repo. The Vite app's `package.json` lives at the root. Removed the `working-directory` so `npm install` and `npm test` run from the root.

## Depends on

- **#173 (JUCE 8.0.13 bump)** should land first or simultaneously, otherwise the `submodules: recursive` checkout will fail on the unreachable JUCE pin instead of progressing into configure.

## Test plan

- [ ] Merge (#173 first or together)
- [ ] Confirm `dev-base-template / cpp-ctest` reaches Build phase (currently dies in Configure)
- [ ] Confirm `dev-base-template / frontend-smoke` reaches the test step (currently fails at `working-directory: web`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to GitHub Actions workflow wiring (dependency installs and build/test commands) and don’t affect runtime code, but may change CI pass/fail behavior.
> 
> **Overview**
> Fixes the `dev-base-template` GitHub Actions workflow so CI matches the repository’s actual build requirements.
> 
> In `cpp-ctest`, it now initializes only the `external/JUCE` submodule and installs `qt6-base-dev` so CMake configuration can succeed.
> 
> In `frontend-smoke`, it bumps Node to `20` and replaces the no-op `npm test` (and removed `web/` working directory assumptions) with `npm run build` to perform a real TypeScript+Vite smoke build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 887ba60e265fd00a903be5e245be1c5d4eb364aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->