### PR TITLE
fix(ci): repair Sprint 1 workflow + disable broken Copilot-Claude sync

### DIFF
--- a/.github/workflows/copilot-claude-sync.yml
+++ b/.github/workflows/copilot-claude-sync.yml
@@ -1,8 +1,11 @@
 name: Copilot-Claude Sync Status
 
+# Manual-only trigger — scripts/copilot-claude-sync.sh is not present in this
+# repo (was never committed or has been removed), so the push trigger has
+# been failing every push to main since whenever the script disappeared.
+# Revive by committing the script and restoring the `push:` trigger below.
+
 on:
-  push:
-    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/iDAW_.github_workflows_sprint_1_core_testing_and_quality.yml
+++ b/.github/workflows/iDAW_.github_workflows_sprint_1_core_testing_and_quality.yml
@@ -21,8 +21,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - name: Init JUCE submodule
+        # Selective init — only external/JUCE. Avoids tying this job to
+        # the health of .worktrees/integration-finalize (the local-worktree
+        # gitlink), which is not a build dependency.
+        run: git submodule update --init --depth 1 external/JUCE
       - name: C++ Build & Test
         run: |
           sudo apt-get update

--- a/.github/workflows/iDAW_.github_workflows_sprint_1_core_testing_and_quality.yml
+++ b/.github/workflows/iDAW_.github_workflows_sprint_1_core_testing_and_quality.yml
@@ -14,17 +14,19 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.9'
-      - run: pip install -e .
+      - run: pip install -e ".[dev]"
       - run: pytest tests/unit/ -v
       - run: pytest tests/integration/ -v || true
   test-cpp:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: C++ Build & Test
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake g++
+          sudo apt-get install -y cmake g++ qt6-base-dev
           mkdir build && cd build
           cmake .. -DCMAKE_BUILD_TYPE=Release
           cmake --build . -j


### PR DESCRIPTION
## Summary

Workflow-only cleanup for two long-standing CI red lights.

### `Sprint 1 – Core Testing & Quality`

**`test-python`** — was running `pip install -e .` (no dev extras), then `pytest tests/unit/ -v` failed with `pytest: command not found` (exit 127). Switched to `pip install -e ".[dev]"` so pytest is on PATH.

**`test-cpp`** — same shape as #174's `dev-base-template` fix:
- `actions/checkout@v4` was missing `submodules: recursive`, so `external/JUCE` wasn't cloned and Configure couldn't find it.
- apt install lacked `qt6-base-dev`, so `CMakeLists.txt:111` `find_package(Qt6 COMPONENTS Core Widgets REQUIRED)` exit-1'd.

### `Copilot-Claude Sync Status`

The workflow invokes `chmod +x scripts/copilot-claude-sync.sh` then `./scripts/copilot-claude-sync.sh`, but **that script does not exist in the repo** (only `sync_entities.py` and `sync_package_to_s3.py` are in `scripts/`). Has been failing every push to main since whenever the script disappeared.

Demoted the trigger to `workflow_dispatch` only (manual) with an explanatory comment in the file. Doesn't delete the workflow — leaves it recoverable: commit the missing script and flip the `push:` trigger back on.

## Depends on

**#173 (JUCE 8.0.13 bump)** should land first or simultaneously. Adding `submodules: recursive` to a checkout that still has the unreachable JUCE pin would otherwise still fail at the checkout step.

## Test plan

- [ ] Merge (alongside or after #173)
- [ ] Confirm `Sprint 1 / test-python` reaches the pytest step (was dying on `pytest: command not found`)
- [ ] Confirm `Sprint 1 / test-cpp` reaches Build (was dying in Configure on missing Qt6)
- [ ] Confirm `Copilot-Claude Sync Status` no longer auto-runs on push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to GitHub Actions workflows, but may affect CI signal by altering dependency installation and C++ build prerequisites.
> 
> **Overview**
> Stops `Copilot-Claude Sync Status` from running on every push by removing the `push` trigger and leaving it as manual-only (`workflow_dispatch`), with an in-file note explaining the missing `scripts/copilot-claude-sync.sh`.
> 
> Repairs the Sprint 1 CI workflow by installing Python dev extras (`pip install -e "..[dev]"`) so `pytest` is available, and by initializing the `external/JUCE` submodule plus installing `qt6-base-dev` to unblock the C++ configure/build steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit faef8f340d7781bd5735e91f1f99446b9fdabaa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->