### PR TITLE
fix(ci): Python 3.9 collection error + missing submodule:recursive in 3 ci.yml jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: recursive
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -108,6 +110,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: recursive
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -142,6 +146,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: recursive
     - name: Install dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: recursive
+    - name: Init JUCE submodule
+      # Selective init — only external/JUCE. Avoids tying this job to the
+      # health of .worktrees/integration-finalize (local-worktree gitlink),
+      # which is not a build dependency.
+      run: git submodule update --init --depth 1 external/JUCE
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -110,8 +113,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: recursive
+    - name: Init JUCE submodule
+      run: git submodule update --init --depth 1 external/JUCE
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -146,8 +149,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: recursive
+    - name: Init JUCE submodule
+      run: git submodule update --init --depth 1 external/JUCE
     - name: Install dependencies
       run: |
         sudo apt-get update

--- a/tests/unit/test_intent_pipeline_regression.py
+++ b/tests/unit/test_intent_pipeline_regression.py
@@ -5,6 +5,8 @@ Assert that emotion_map, imagery_texture, and BPM/tempo are preserved
 through normalize → validate → expand. No partial intent fallback.
 """
 
+from __future__ import annotations
+
 import pytest
 
 pytest.importorskip("fastapi", reason="FastAPI required for request models")


### PR DESCRIPTION
## Summary

Two distinct sources of CI red, both fixable by workflow/test-file edits.

### 1. `tests/unit/test_intent_pipeline_regression.py` — Python 3.9 collection error

pytest collection failed on Python 3.9 with:

```
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
ERROR tests/unit/test_intent_pipeline_regression.py - TypeError: ...
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
```

Lines 21-22 use PEP 604 union syntax `str | None`, which is Python 3.10+ only. CI matrices still include 3.9 (Sprint 1 workflow pins `3.9`, Tests workflow runs `3.9/3.11/3.12`).

Added `from __future__ import annotations` after the docstring — PEP 563 defers annotation evaluation, making the union syntax parse fine on 3.9 without changing runtime behavior. One-line fix to keep 3.9 in the matrix.

This collection error was breaking **two workflows simultaneously**: `Tests` (job `test (3.9)`) and `Sprint Suite` (job `Sprint 6 – Advanced Theory and AI`).

### 2. `ci.yml` — three C++ jobs missing `submodules: recursive`

Three jobs in `ci.yml` were doing plain `actions/checkout@v4` without the `submodules:` argument:

- `cpp_build`
- `valgrind_memory` (Valgrind Memory Testing)
- `performance_regression` (Performance Regression Tests)

Each then exit-1'd in Configure with `CMakeLists.txt:126 (find_package)` / "JUCE not found" because `external/JUCE` wasn't cloned.

`cpp_tests` is intentionally left as-is — it downloads build artifacts from `cpp_build`, so it doesn't need its own submodule checkout.

## Depends on

**#173 (JUCE 8.0.13 bump)** — the recursive checkout has no effect until the JUCE pin is fetchable from `juce-framework/JUCE`.

## Test plan

- [ ] Merge (after or alongside #173)
- [ ] Confirm `Tests / test (3.9)` reaches the actual test run (was dying in collection)
- [ ] Confirm `Sprint Suite / Sprint 6` reaches the actual test run
- [ ] Confirm `cpp_build`, `valgrind_memory`, `performance_regression` reach Build phase (were dying in Configure on missing JUCE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI/test-only changes; the main risk is minor CI flakiness if the JUCE submodule pin or fetch depth causes checkout issues.
> 
> **Overview**
> Fixes CI failures by ensuring C++ workflow jobs fetch the `external/JUCE` dependency: `cpp_build`, `valgrind_memory`, and `performance_regression` now explicitly run `git submodule update --init --depth 1 external/JUCE` after checkout.
> 
> Unblocks pytest collection on Python 3.9 by adding `from __future__ import annotations` to `tests/unit/test_intent_pipeline_regression.py`, avoiding runtime evaluation issues with PEP 604 (`str | None`) type hints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12a010fbfc59dd95a878e8c7a949a3107b9392ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->