### PR TITLE
fix(deps): add librosa to [audio] extra (unblock platform_support audio test)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
 audio = [
     "soundfile>=0.12",
     "pydub>=0.25",
+    "librosa>=0.10,<1",
 ]
 jepa = [
     "lhotse>=1.20",


### PR DESCRIPTION
Platform Support's Test Optional Deps job failed with `ModuleNotFoundError: No module named 'librosa'` at the Test audio features step. Workflow installs `.[dev,audio]` and then runs `python -c 'import librosa; import soundfile'`, but librosa was only in the [ml] extra. Adding it to [audio] (kept in [ml] too for backward compat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only change confined to packaging metadata; main impact is a potentially heavier install for users who opt into `.[audio]`.
> 
> **Overview**
> Updates `pyproject.toml` to include `librosa>=0.10,<1` in the `audio` optional-dependencies extra, ensuring environments installed with `.[audio]` have the required package available (in addition to it already being present in `ml`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d467001d6c983a9062a7c84b98a3e7074045031f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->