### PR TITLE
fix(tests): point sync_*_rust tests at engine/intent_ir (was stale src-tauri path)

### DIFF
--- a/tests/unit/test_sync_emotion.py
+++ b/tests/unit/test_sync_emotion.py
@@ -35,7 +35,7 @@ def test_emotion_ts_exists_after_sync():
 
 
 def test_emotion_rust_exists_after_sync():
-    rs_path = ROOT / "src-tauri" / "src" / "generated" / "emotion.rs"
+    rs_path = ROOT / "engine" / "intent_ir" / "src" / "generated" / "emotion.rs"
     assert rs_path.exists(), "emotion.rs not generated"
     content = rs_path.read_text()
     assert "valence" in content

--- a/tests/unit/test_sync_intent_frame.py
+++ b/tests/unit/test_sync_intent_frame.py
@@ -39,7 +39,7 @@ def test_intent_frame_ts_exists_after_sync():
 
 
 def test_intent_frame_rust_exists_after_sync():
-    rs_path = ROOT / "src-tauri" / "src" / "generated" / "intent_frame.rs"
+    rs_path = ROOT / "engine" / "intent_ir" / "src" / "generated" / "intent_frame.rs"
     assert rs_path.exists(), "intent_frame.rs not generated"
     content = rs_path.read_text()
     assert "IntentFrame" in content


### PR DESCRIPTION
scripts/sync_entities.py was migrated to write Rust output to `engine/intent_ir/src/generated/` when `src-tauri/` was removed, but the matching tests in `test_sync_emotion.py` and `test_sync_intent_frame.py` were never updated. They still assert on the stale `src-tauri/src/generated/` path which no longer exists.

CI fails on every `Run unit tests` / `Run extended tests` job across the Platform Support matrix (windows/macos/ubuntu × 3.9-3.13) with:

```
AssertionError: emotion.rs not generated
   +    where exists = WindowsPath('D:/a/KmiDi/KmiDi/src-tauri/src/generated/emotion.rs').exists
AssertionError: intent_frame.rs not generated
   +    where exists = WindowsPath('D:/a/KmiDi/KmiDi/src-tauri/src/generated/intent_frame.rs').exists
```

Note the `src-tauri/` in the asserted paths — that directory no longer exists. The script's header literally says `# Rust codegen now targets the engine/intent_ir crate (src-tauri was removed).`

Fix: 2-line change updating the test paths to match what the script actually writes. `git diff --stat` shows 2 insertions / 2 deletions.

Verified locally — both files' full 3-test suites pass (6/6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that updates file path assertions to match the current Rust codegen output location, with no production logic impact.
> 
> **Overview**
> Fixes failing sync entity unit tests by updating the asserted Rust output paths for `emotion.rs` and `intent_frame.rs` to `engine/intent_ir/src/generated/` (replacing the removed `src-tauri/src/generated/` location).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e108fd71f5648a4e9b5cfa0cdb460aa07092797c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->