### PR TITLE
fix(ci): install httpx for platform_support tests (TestClient dep)

### DIFF
--- a/.github/workflows/platform_support.yml
+++ b/.github/workflows/platform_support.yml
@@ -68,7 +68,10 @@ jobs:
       
       - name: Install test dependencies
         run: |
-          pip install pytest pytest-mock pytest-cov pydantic
+          # httpx is required by fastapi.testclient.TestClient (via starlette);
+          # without it test_api_audit_fixes.py errors out at setup with
+          # "RuntimeError: The starlette.testclient module requires httpx".
+          pip install pytest pytest-mock pytest-cov pydantic httpx
       
       - name: Run unit tests
         run: |


### PR DESCRIPTION
Every cell of the platform_support `Test <os> - Python <ver>` matrix (3 OS × 5 Python = 15 cells) errored at fixture setup for all 11 tests in `tests/unit/test_api_audit_fixes.py` with:

```
ModuleNotFoundError: No module named 'httpx'
RuntimeError: The starlette.testclient module requires the httpx package to be installed.
```

The fixture instantiates `fastapi.testclient.TestClient`, which delegates HTTP to httpx via starlette in recent versions. httpx is in the `[dev]` extra in `pyproject.toml`, but this job installs `pip install -e .` (no extras) and then a hand-rolled `pytest pytest-mock pytest-cov pydantic` list that doesn't include httpx.

Surgical fix: add `httpx` to the list. Keeps the rest of the `[dev]` extra (mypy/black/ruff/flake8) out of this matrix install.

Verified locally with venv (httpx 0.28.1): all 11 tests in `test_api_audit_fixes.py` collect cleanly (previously errored at setup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that adds a missing test dependency; main impact is slightly longer install time and potential dependency resolution issues in the workflow matrix.
> 
> **Overview**
> Fixes failing `platform_support` CI runs by adding `httpx` to the workflow’s test dependency install step so `fastapi.testclient.TestClient` (via Starlette) can initialize during unit test setup.
> 
> Also documents in-line why `httpx` is required to prevent recurring setup-time errors in `tests/unit/test_api_audit_fixes.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f49ece036427b2cd021160ec044ecd018843724. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->