### PR TITLE
fix(ci): bump JUCE submodule to 8.0.13 + install Linux X11/freetype deps

### DIFF
--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -53,6 +53,10 @@ jobs:
             libsndfile1-dev \
             libfftw3-dev \
             ccache
+
+      - name: Install JUCE Linux deps
+        if: runner.os == 'Linux'
+        run: scripts/ci/install_juce_linux_deps.sh
       
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/ci-rt-harness.yml
+++ b/.github/workflows/ci-rt-harness.yml
@@ -42,6 +42,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y cmake ninja-build build-essential
 
+      - name: Install JUCE Linux deps
+        if: runner.os == 'Linux'
+        run: scripts/ci/install_juce_linux_deps.sh
+
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         run: brew install cmake ninja

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,8 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y cmake ninja-build build-essential qt6-base-dev
+    - name: Install JUCE Linux deps
+      run: scripts/ci/install_juce_linux_deps.sh
     - name: Configure CMake
       run: |
         mkdir build && cd build
@@ -128,6 +130,8 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y cmake ninja-build build-essential qt6-base-dev valgrind
+    - name: Install JUCE Linux deps
+      run: scripts/ci/install_juce_linux_deps.sh
     - name: Configure CMake (Debug)
       run: |
         mkdir build && cd build
@@ -164,6 +168,8 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y cmake ninja-build build-essential qt6-base-dev
+    - name: Install JUCE Linux deps
+      run: scripts/ci/install_juce_linux_deps.sh
     - name: Configure CMake (Release)
       run: |
         mkdir build && cd build
@@ -193,6 +199,8 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y cmake ninja-build build-essential qt6-base-dev lcov
+    - name: Install JUCE Linux deps
+      run: scripts/ci/install_juce_linux_deps.sh
     - name: Configure CMake (Coverage)
       run: |
         mkdir build && cd build

--- a/.github/workflows/dev-base-template.yml
+++ b/.github/workflows/dev-base-template.yml
@@ -73,6 +73,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y cmake ninja-build g++ qt6-base-dev
+      - name: Install JUCE Linux deps
+        run: scripts/ci/install_juce_linux_deps.sh
       - name: Configure
         run: |
           cmake -S . -B build -G Ninja

--- a/.github/workflows/pre-training-hardening.yml
+++ b/.github/workflows/pre-training-hardening.yml
@@ -66,6 +66,8 @@ jobs:
           submodules: recursive
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y qt6-base-dev
+      - name: Install JUCE Linux deps
+        run: scripts/ci/install_juce_linux_deps.sh
       - name: Configure and build runtime contract tests
         run: |
           cmake -S . -B build-ci-runtime -DOFFLINE_BUILD=OFF -DJUCE_EXTERNAL_ROOT= -DKELLY_ENABLE_TESTS=ON

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,10 @@ jobs:
             sudo apt-get install -y clang-14
           fi
 
+      - name: Install JUCE Linux deps
+        if: runner.os == 'Linux'
+        run: scripts/ci/install_juce_linux_deps.sh
+
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
@@ -144,6 +148,9 @@ jobs:
             libxinerama-dev \
             libxcursor-dev
 
+      - name: Install JUCE Linux deps
+        run: scripts/ci/install_juce_linux_deps.sh
+
       - name: Configure CMake (Debug)
         run: |
           cmake -B build \
@@ -201,6 +208,9 @@ jobs:
             libfreetype6-dev \
             libx11-dev
 
+      - name: Install JUCE Linux deps
+        run: scripts/ci/install_juce_linux_deps.sh
+
       - name: Configure CMake (Release with optimizations)
         run: |
           cmake -B build \
@@ -248,6 +258,9 @@ jobs:
             libasound2-dev \
             libfreetype6-dev \
             libx11-dev
+
+      - name: Install JUCE Linux deps
+        run: scripts/ci/install_juce_linux_deps.sh
 
       - name: Configure CMake
         run: |
@@ -298,6 +311,9 @@ jobs:
             libxinerama-dev \
             libxcursor-dev
 
+      - name: Install JUCE Linux deps
+        run: scripts/ci/install_juce_linux_deps.sh
+
       - name: Configure CMake
         run: |
           cmake -B build \
@@ -344,6 +360,9 @@ jobs:
             libasound2-dev \
             libfreetype6-dev \
             libx11-dev
+
+      - name: Install JUCE Linux deps
+        run: scripts/ci/install_juce_linux_deps.sh
 
       - name: Configure CMake (with coverage)
         run: |

--- a/.github/workflows/v1-release.yml
+++ b/.github/workflows/v1-release.yml
@@ -54,6 +54,10 @@ jobs:
             qt6-base-dev \
             ninja-build
 
+      - name: Install JUCE Linux deps
+        if: runner.os == 'Linux'
+        run: scripts/ci/install_juce_linux_deps.sh
+
       - name: Install Python Toolchain
         run: |
           python -m pip install --upgrade pip

--- a/scripts/ci/install_juce_linux_deps.sh
+++ b/scripts/ci/install_juce_linux_deps.sh
@@ -15,8 +15,8 @@
 
 set -euo pipefail
 
-if [[ "${RUNNER_OS:-Linux}" != "Linux" ]] && [[ "$(uname -s)" != "Linux" ]]; then
-    echo "install_juce_linux_deps: not Linux, skipping"
+if [[ -n "${RUNNER_OS:-}" && "${RUNNER_OS}" != "Linux" ]] || [[ "$(uname -s)" != "Linux" ]]; then
+    echo "install_juce_linux_deps: not Linux (RUNNER_OS=${RUNNER_OS:-unset}, uname=$(uname -s)), skipping"
     exit 0
 fi
 

--- a/scripts/ci/install_juce_linux_deps.sh
+++ b/scripts/ci/install_juce_linux_deps.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# install_juce_linux_deps.sh — apt packages required to build JUCE 8 on Linux.
+#
+# JUCE 8's juceaide (the build-time helper that generates resource files) and
+# the GUI modules (juce_graphics, juce_gui_basics) link against X11, freetype,
+# fontconfig, xkbcommon, and OpenGL. CI workflows that build any target which
+# pulls in external/JUCE need these packages on Linux.
+#
+# Audio / engine deps (libasound2-dev, etc.) are NOT installed here — those
+# are project-specific and stay in each workflow's apt block.
+#
+# Usage:
+#   - name: Install JUCE Linux deps
+#     run: scripts/ci/install_juce_linux_deps.sh
+
+set -euo pipefail
+
+if [[ "${RUNNER_OS:-Linux}" != "Linux" ]] && [[ "$(uname -s)" != "Linux" ]]; then
+    echo "install_juce_linux_deps: not Linux, skipping"
+    exit 0
+fi
+
+sudo apt-get update -qq
+
+# JUCE 8 build-time + runtime Linux deps.
+sudo apt-get install -y --no-install-recommends \
+    libfreetype-dev \
+    libfontconfig1-dev \
+    libxrandr-dev \
+    libxinerama-dev \
+    libxcursor-dev \
+    libxcomposite-dev \
+    libxkbcommon-dev \
+    libgl1-mesa-dev


### PR DESCRIPTION
## Summary

Two coupled fixes for CI that the previous revert (\`f2a72e8d\`) explicitly deferred to a follow-up:

1. **JUCE submodule pin** bumped from \`0c3fa0ad\` (upstream GC'd, every CI run failed at \`git submodule update --init external/JUCE\` with \`upload-pack: not our ref\`) to **8.0.13** (\`7c9d3783b127263d72bb65fe0a7e2dc8a02a7ac2\`, the latest tagged 8.x release).
2. **JUCE 8 Linux build deps** added to every CI workflow that compiles a JUCE-touching target. JUCE 8's juceaide + GUI modules need \`libfreetype-dev\`, \`libfontconfig1-dev\`, \`libxrandr-dev\`, \`libxinerama-dev\`, \`libxcursor-dev\`, \`libxcomposite-dev\`, \`libxkbcommon-dev\`, and \`libgl1-mesa-dev\`. The previous bump attempt (\`109d3bc6\`) was rolled back exactly because these weren't installed.

A single shared installer, \`scripts/ci/install_juce_linux_deps.sh\`, holds the apt list so future drift stays in one place. Every JUCE-building workflow gains a \`- name: Install JUCE Linux deps\` step that invokes it.

## Files changed

| File | Change |
|---|---|
| \`external/JUCE\` | submodule pin \`0c3fa0ad\` → \`7c9d3783\` (refs/tags/8.0.13) |
| \`scripts/ci/install_juce_linux_deps.sh\` | new, executable; installs 8 apt packages; SKIPs on non-Linux |
| \`.github/workflows/ci-cpp.yml\` | + 1 install step |
| \`.github/workflows/ci-rt-harness.yml\` | + 1 install step |
| \`.github/workflows/ci.yml\` | + 4 install steps (one per Linux job) |
| \`.github/workflows/test.yml\` | + 6 install steps |
| \`.github/workflows/dev-base-template.yml\` | + 1 install step |
| \`.github/workflows/v1-release.yml\` | + 1 install step (Linux only) |
| \`.github/workflows/pre-training-hardening.yml\` | + 1 install step |

## Test plan

- [x] \`scripts/ci/install_juce_linux_deps.sh\` is executable, \`set -euo pipefail\`, SKIPs on non-Linux (\`RUNNER_OS\`/\`uname -s\` check)
- [ ] CI on this PR — primary check. C++ CI / RT Harness CI workflows that were red on \`main\` should turn green on this branch:
  - submodule \`update --init\` resolves (pin is reachable)
  - juceaide configures without missing-package errors
- [ ] If anything in the apt list is wrong on a specific Ubuntu image, the script's the one place to fix it

## Out of scope

- Python Lint & Format (444 black-reformat backlog) — separate repo-wide change
- Tauri / Frontend / Python CI workflows — they don't build JUCE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI workflow steps and a new Linux-only apt installer script; main impact is potential CI failures if the package list is incomplete or conflicts with Ubuntu images.
> 
> **Overview**
> Adds a shared `scripts/ci/install_juce_linux_deps.sh` helper to install JUCE’s required Linux X11/font/OpenGL build dependencies (and safely *no-op* on non-Linux runners).
> 
> Updates all relevant GitHub Actions workflows to invoke this script in Linux jobs so JUCE-touching builds have consistent system dependencies across CI (C++ builds/tests, RT harness, coverage, release, and hardening gates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f1e09bef6967c25ec5a326d2478d471233a4ac3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->