### PR TITLE
fix(ci): unblock downstream CMake failures exposed by JUCE fix

### DIFF
--- a/.github/workflows/iDAW_.github_workflows_sprint_1_core_testing_and_quality.yml
+++ b/.github/workflows/iDAW_.github_workflows_sprint_1_core_testing_and_quality.yml
@@ -26,11 +26,16 @@ jobs:
         # the health of .worktrees/integration-finalize (the local-worktree
         # gitlink), which is not a build dependency.
         run: git submodule update --init --depth 1 external/JUCE
-      - name: C++ Build & Test
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake g++ qt6-base-dev
+          sudo apt-get install -y cmake ninja-build g++ qt6-base-dev
+      - name: Install JUCE Linux deps
+        run: scripts/ci/install_juce_linux_deps.sh
+      - name: C++ Build & Test
+        run: |
           mkdir build && cd build
-          cmake .. -DCMAKE_BUILD_TYPE=Release
+          cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release
           cmake --build . -j
           ctest --output-on-failure

--- a/.github/workflows/v1-release.yml
+++ b/.github/workflows/v1-release.yml
@@ -30,9 +30,10 @@ jobs:
           node-version: "20"
 
       - name: Setup Rust
-        # Kept for engine/intent_ir crate if needed; no Tauri dependency
+        # Required on every platform: engine/intent_ir crate is built when CMake
+        # configures the tree (auto-enabled by intent_ir/CMakeLists.txt when no
+        # prebuilt libintent_ir.a is present).
         uses: dtolnay/rust-toolchain@stable
-        if: runner.os == 'macOS'
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -75,6 +76,7 @@ jobs:
         run: ./bootstrap.sh
 
       - name: Build Headless Core
+        shell: bash
         run: |
           PYBIND_DIR=$(python -c "import pybind11; print(pybind11.get_cmake_dir())")
           cmake -B build -S . \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -884,7 +884,13 @@ if(BUILD_PENTA_TESTS)
         GIT_SHALLOW TRUE
     )
     FetchContent_MakeAvailable(googletest)
-    add_subdirectory(tests/penta_core)
+    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/tests/penta_core/CMakeLists.txt)
+        add_subdirectory(tests/penta_core)
+    else()
+        message(STATUS
+            "BUILD_PENTA_TESTS=ON but tests/penta_core/ is absent; "
+            "googletest is fetched but no top-level penta_core test target is added.")
+    endif()
 endif()
 
 # Tracy profiling

--- a/engine/intent_ir/CMakeLists.txt
+++ b/engine/intent_ir/CMakeLists.txt
@@ -15,6 +15,14 @@ set(SOURCE_FFI_HEADER "${CMAKE_SOURCE_DIR}/src/bridge/intent_ir_ffi.h")
 
 file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/include")
 
+# Auto-enable rebuild on fresh checkouts (e.g. CI) when no prebuilt library
+# exists and cargo is available. Keeps the prebuilt path fast for repeat local
+# builds while letting fresh trees configure without a manual cargo step.
+if(NOT INTENT_IR_REBUILD_RUST AND NOT EXISTS ${PREBUILT_RUST_LIB} AND CARGO_EXECUTABLE)
+    message(STATUS "intent_ir: no prebuilt ${PREBUILT_RUST_LIB}; auto-enabling INTENT_IR_REBUILD_RUST")
+    set(INTENT_IR_REBUILD_RUST ON)
+endif()
+
 if(INTENT_IR_REBUILD_RUST)
     if(NOT CARGO_EXECUTABLE)
         message(FATAL_ERROR "cargo is required when INTENT_IR_REBUILD_RUST=ON")
@@ -22,7 +30,7 @@ if(INTENT_IR_REBUILD_RUST)
 
     add_custom_command(
         OUTPUT ${PREBUILT_RUST_LIB}
-        COMMAND ${CARGO_EXECUTABLE} build --release --locked --manifest-path ${CMAKE_CURRENT_SOURCE_DIR}/Cargo.toml
+        COMMAND ${CARGO_EXECUTABLE} build --release --manifest-path ${CMAKE_CURRENT_SOURCE_DIR}/Cargo.toml
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         COMMENT "Building Intent IR Rust crate"
         VERBATIM

--- a/src_penta-core/CMakeLists.txt
+++ b/src_penta-core/CMakeLists.txt
@@ -134,10 +134,31 @@ option(BUILD_PENTA_TESTS "Build penta-core tests" ON)
 if(BUILD_PENTA_TESTS)
     enable_testing()
 
-    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../external/googletest/CMakeLists.txt")
+    # Resolve googletest in priority order:
+    #   1. Already-imported target from the parent build (root CMakeLists' FetchContent).
+    #   2. Vendored copy at external/googletest/.
+    #   3. System install via find_package(GTest).
+    #   4. FetchContent (network), unless KMIDI_OFFLINE_BUILD is ON.
+    if(NOT TARGET GTest::gtest AND NOT TARGET gtest
+       AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../external/googletest/CMakeLists.txt")
         add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../external/googletest"
                          "${CMAKE_CURRENT_BINARY_DIR}/external-googletest"
                          EXCLUDE_FROM_ALL)
+    endif()
+
+    if(NOT TARGET GTest::gtest AND NOT TARGET gtest)
+        find_package(GTest QUIET)
+    endif()
+
+    if(NOT TARGET GTest::gtest AND NOT TARGET gtest AND NOT KMIDI_OFFLINE_BUILD)
+        include(FetchContent)
+        FetchContent_Declare(
+            googletest
+            GIT_REPOSITORY https://github.com/google/googletest.git
+            GIT_TAG v1.14.0
+            GIT_SHALLOW TRUE
+        )
+        FetchContent_MakeAvailable(googletest)
     endif()
 
     if(TARGET GTest::gtest AND TARGET GTest::gtest_main)
@@ -148,8 +169,8 @@ if(BUILD_PENTA_TESTS)
         set(_GTEST_MAIN_LIB gtest_main)
     else()
         message(FATAL_ERROR
-            "BUILD_PENTA_TESTS=ON requires local googletest. "
-            "Provide external/googletest or pre-install GTest.")
+            "BUILD_PENTA_TESTS=ON requires googletest. "
+            "Provide external/googletest, install GTest, or build online (KMIDI_OFFLINE_BUILD=OFF).")
     endif()
 
     # Create test executable
@@ -157,18 +178,19 @@ if(BUILD_PENTA_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/../tests/penta_core/*.cpp
     )
     if("${TEST_SOURCES}" STREQUAL "")
-        message(FATAL_ERROR
-            "BUILD_PENTA_TESTS=ON but no test sources were found under tests/penta_core.")
+        message(STATUS
+            "BUILD_PENTA_TESTS=ON but no test sources under tests/penta_core/; "
+            "skipping penta_tests target.")
+    else()
+        add_executable(penta_tests ${TEST_SOURCES})
+
+        target_link_libraries(penta_tests PRIVATE
+            penta_core
+            ${_GTEST_LIB}
+            ${_GTEST_MAIN_LIB}
+        )
+
+        include(GoogleTest)
+        gtest_discover_tests(penta_tests)
     endif()
-
-    add_executable(penta_tests ${TEST_SOURCES})
-
-    target_link_libraries(penta_tests PRIVATE
-        penta_core
-        ${_GTEST_LIB}
-        ${_GTEST_MAIN_LIB}
-    )
-
-    include(GoogleTest)
-    gtest_discover_tests(penta_tests)
 endif()


### PR DESCRIPTION
## Summary

PR #183 cleared JUCE submodule + Linux X11/freetype install. That exposed several downstream blockers that had been failing first — `intent_ir/CMakeLists.txt:51` (no prebuilt Rust lib), `src_penta-core/CMakeLists.txt:150` (googletest not found), `v1-release.yml` Windows bash-vs-pwsh syntax, Sprint 1 missing JUCE deps. None of these workflows were green on `main`; this commit addresses the **configure-step** failures.

## Fixes

### `engine/intent_ir/CMakeLists.txt`
- Auto-enable `INTENT_IR_REBUILD_RUST` when no prebuilt `libintent_ir.a` exists and `cargo` is available (covers fresh CI checkouts without per-workflow cargo-build steps).
- Drop `--locked` from cargo invocation: `Cargo.lock` isn't checked in, and `--locked` refuses to create it.

### `src_penta-core/CMakeLists.txt`
- Resolve googletest in priority order: already-imported target → vendored `external/googletest/` → `find_package(GTest)` → `FetchContent` (unless `KMIDI_OFFLINE_BUILD=ON`).
- Gracefully skip `penta_tests` target with a `STATUS` message when `tests/penta_core/*.cpp` sources are absent (was `FATAL_ERROR`).

### `CMakeLists.txt` (root)
- Only `add_subdirectory(tests/penta_core)` when the directory exists.

### `.github/workflows/v1-release.yml`
- Install Rust toolchain on **all three** platforms — `intent_ir` now auto-builds during cmake configure on every platform, not just macOS.
- Set `shell: bash` on the Build Headless Core step so `PYBIND_DIR=\$(python -c …)` works under Windows pwsh default.

### `.github/workflows/iDAW_.github_workflows_sprint_1_core_testing_and_quality.yml`
- Install Rust toolchain and shared JUCE Linux deps before configuring.
- Use Ninja generator for consistency.

## Out of scope

`ci.yml` and `test.yml` C++ Build/Tests jobs enable `BUILD_PENTA_TESTS=ON` but then `ninja penta_tests` against a target whose sources (`tests/penta_core/*.cpp`) **don't exist in the tree**. That's a structural mismatch needing a separate decision (restore the sources or rewrite the workflow), not a configure-step patch. The graceful-degradation in this PR lets cmake configure succeed; the workflow build steps will still fail with "unknown target: penta_tests" until that's addressed.

## Test plan

Verified locally:
- ✅ \`cmake -S . -B build -G Ninja -DBUILD_KELLY_CORE=OFF -DBUILD_DESKTOP=OFF -DBUILD_PLUGINS=OFF -DBUILD_PYTHON_BINDINGS=OFF\` — configures cleanly, intent_ir auto-builds via cargo (libintent_ir.a 8.4 MB produced).
- ✅ \`cmake … -DBUILD_KELLY_CORE=ON -DBUILD_KELLY_FFI=ON\` — canonical configure passes, KellyCore + intent_ir linkage detected.
- ✅ \`cmake … -DBUILD_PENTA_TESTS=ON\` (ci.yml flags) — configure now succeeds with graceful "no test sources" STATUS message (was FATAL_ERROR).
- [ ] CI run on this PR — primary verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI workflows and CMake dependency resolution/build behavior (Rust auto-build, googletest sourcing, optional test targets), which can affect cross-platform builds and reproducibility.
> 
> **Overview**
> Unblocks CI/CMake configure on fresh checkouts by **auto-building the Rust `intent_ir` crate** when no prebuilt `libintent_ir.a` exists (and removing `cargo --locked`), and by installing Rust in workflows where CMake now triggers that build.
> 
> Makes test and dependency setup more robust: root CMake only adds `tests/penta_core` when present, `src_penta-core` resolves googletest via imported/vendored/system/FetchContent (respecting `KMIDI_OFFLINE_BUILD`), and skips creating `penta_tests` when no sources exist instead of failing.
> 
> Updates GitHub Actions C++ workflows to use Ninja, install missing Linux/JUCE deps, and forces `bash` for the Windows headless-core build step to avoid shell syntax issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 082c6b0dd661fe214d8276dc4460c0191f4b0ff4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->