### PR TITLE
feat(ml): constrained decoding + latent norm + audio chunking primitives

### DIFF
--- a/music_brain/audio/chunking.py
+++ b/music_brain/audio/chunking.py
@@ -1,0 +1,148 @@
+"""Audio chunking primitives for streaming inference.
+
+Three patterns:
+
+  - ``iter_chunks`` — stateless generator over fixed-size windows with
+    configurable hop; used to feed batched audio into models that expect
+    a constant input length.
+  - ``pad_to_chunk_boundary`` — make a signal a clean multiple of
+    ``chunk_size``; ``mode="reflect"`` mirrors the tail to avoid the DC
+    discontinuity zero-padding introduces at chunk boundaries.
+  - ``overlap_add`` / :class:`WindowedOverlapAdd` — stateless and stateful
+    reconstruction back to a continuous signal; useful when a model
+    operates on overlapping windows and the host needs to stitch them.
+
+All functions are stateless except ``WindowedOverlapAdd``. No ML
+dependencies — works on plain NumPy arrays.
+
+Goal-list ties: Streaming audio chunking, Chunked latent prediction
+(prerequisite), Incremental decoding pipeline (prerequisite).
+"""
+
+from __future__ import annotations
+
+from typing import Iterator, List, Literal
+
+import numpy as np
+
+
+def iter_chunks(
+    signal: np.ndarray,
+    chunk_size: int,
+    hop_size: int,
+) -> Iterator[np.ndarray]:
+    """Yield successive ``chunk_size``-sample views over ``signal`` with stride ``hop_size``.
+
+    Trailing samples that don't fill a complete chunk are dropped — use
+    :func:`pad_to_chunk_boundary` first if every sample must be covered.
+
+    Views are NumPy slices, so they alias ``signal``; copy if you need
+    independent buffers downstream.
+    """
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be > 0")
+    if hop_size <= 0:
+        raise ValueError("hop_size must be > 0")
+    signal = np.asarray(signal)
+    n = signal.shape[0]
+    start = 0
+    while start + chunk_size <= n:
+        yield signal[start : start + chunk_size]
+        start += hop_size
+
+
+def pad_to_chunk_boundary(
+    signal: np.ndarray,
+    chunk_size: int,
+    mode: Literal["zero", "reflect"] = "zero",
+) -> np.ndarray:
+    """Pad ``signal`` along the leading axis to a multiple of ``chunk_size``.
+
+    ``mode="zero"`` appends zeros. ``mode="reflect"`` mirrors the tail
+    (avoids the DC discontinuity zero-padding can introduce).
+    """
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be > 0")
+    signal = np.asarray(signal)
+    n = signal.shape[0]
+    remainder = n % chunk_size
+    if remainder == 0:
+        return signal
+    pad_len = chunk_size - remainder
+    if mode == "zero":
+        pad = np.zeros(pad_len, dtype=signal.dtype)
+    elif mode == "reflect":
+        # Mirror the last `pad_len` samples (excluding the last to avoid duplicates).
+        # Example: [1,2,3,4,5,6] pad 2 → [5, 4]
+        if pad_len > n:
+            raise ValueError("reflect padding requires pad_len <= signal length")
+        pad = signal[n - pad_len - 1 : n - 1][::-1].copy()
+    else:
+        raise ValueError(f"unsupported mode: {mode!r}")
+    return np.concatenate([signal, pad])
+
+
+def overlap_add(chunks: List[np.ndarray], hop_size: int) -> np.ndarray:
+    """Reconstruct a continuous signal from chunks by overlap-summing.
+
+    All chunks must have the same length. ``hop_size`` controls the stride
+    between successive chunk starts; ``hop_size == chunk_size`` reverses
+    non-overlapping chunking exactly.
+    """
+    if not chunks:
+        return np.zeros(0, dtype=np.float32)
+    if hop_size <= 0:
+        raise ValueError("hop_size must be > 0")
+    chunks = [np.asarray(c) for c in chunks]
+    chunk_size = chunks[0].shape[0]
+    for c in chunks:
+        if c.shape[0] != chunk_size:
+            raise ValueError("all chunks must have the same length")
+    out_len = hop_size * (len(chunks) - 1) + chunk_size
+    out = np.zeros(out_len, dtype=chunks[0].dtype)
+    for i, c in enumerate(chunks):
+        start = i * hop_size
+        out[start : start + chunk_size] += c
+    return out
+
+
+class WindowedOverlapAdd:
+    """Stateful streaming overlap-add reconstruction.
+
+    Call :meth:`push` once per arriving model output chunk; it returns the
+    next ``hop_size`` finalized output samples. Call :meth:`flush` at end
+    of stream to drain whatever overlap is still in the buffer.
+
+    The buffer always holds ``chunk_size`` samples; on each push the input
+    chunk is summed into the buffer, the leading ``hop_size`` samples are
+    emitted, and the rest is left-shifted with ``hop_size`` zeros appended
+    at the tail to receive future overlaps.
+    """
+
+    def __init__(self, chunk_size: int, hop_size: int) -> None:
+        if chunk_size <= 0 or hop_size <= 0:
+            raise ValueError("chunk_size and hop_size must be > 0")
+        if hop_size > chunk_size:
+            raise ValueError("hop_size must be <= chunk_size")
+        self.chunk_size = chunk_size
+        self.hop_size = hop_size
+        self._buf = np.zeros(chunk_size, dtype=np.float32)
+
+    def push(self, chunk: np.ndarray) -> np.ndarray:
+        """Add ``chunk`` into the buffer and return the next emit-window."""
+        chunk = np.asarray(chunk, dtype=np.float32)
+        if chunk.shape[0] != self.chunk_size:
+            raise ValueError(
+                f"push() expected chunk of length {self.chunk_size}, got {chunk.shape[0]}"
+            )
+        self._buf += chunk
+        out = self._buf[: self.hop_size].copy()
+        # Left-shift remaining samples; pad tail with zeros for future overlap.
+        new_buf = np.zeros(self.chunk_size, dtype=np.float32)
+        new_buf[: self.chunk_size - self.hop_size] = self._buf[self.hop_size :]
+        self._buf = new_buf
+        return out
+
+    def flush(self) -> np.ndarray:
+        """Return remaining ``chunk_size - hop_size`` samples of overlap tail."""
+        return self._buf[: self.chunk_size - self.hop_size].copy()

--- a/music_brain/decoding/__init__.py
+++ b/music_brain/decoding/__init__.py
@@ -1,0 +1,19 @@
+"""Decoding primitives for symbolic and token-level music generation."""
+
+from music_brain.decoding.constrained import (
+    apply_mask,
+    apply_temperature,
+    greedy_argmax,
+    sample_from_probs,
+    top_k_filter,
+    top_p_filter,
+)
+
+__all__ = [
+    "apply_mask",
+    "apply_temperature",
+    "greedy_argmax",
+    "sample_from_probs",
+    "top_k_filter",
+    "top_p_filter",
+]

--- a/music_brain/decoding/constrained.py
+++ b/music_brain/decoding/constrained.py
@@ -1,0 +1,136 @@
+"""Constraint-aware decoding primitives.
+
+A library-agnostic toolkit for shaping probability distributions before
+sampling: temperature scaling, top-k truncation, top-p (nucleus) truncation,
+allow/forbid masking, deterministic greedy selection, and seedable sampling.
+
+These primitives compose — each takes and returns a 1-D ``np.ndarray`` of
+probabilities so they can be chained in any order ahead of
+``sample_from_probs`` or ``greedy_argmax``. They are deliberately decoupled
+from any specific model runtime: callers feed in their own logits, the
+shape stage runs on CPU/NumPy, and sampling honours a caller-provided RNG
+so behaviour is fully reproducible.
+
+Goal-list ties: Constraint-based decoding, Top-k/top-p constrained decoding,
+Greedy low-jitter decoding, Constraint-aware generation.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+
+def apply_temperature(logits: np.ndarray, temperature: float = 1.0) -> np.ndarray:
+    """Softmax over ``logits / temperature``.
+
+    Use temperature 1.0 for unmodified softmax, < 1 to sharpen toward the
+    argmax, > 1 to flatten. Temperature 0 raises — use ``greedy_argmax``
+    directly for deterministic selection.
+    """
+    if temperature <= 0.0:
+        raise ValueError("temperature must be > 0; use greedy_argmax() for 0 / deterministic")
+    scaled = np.asarray(logits, dtype=np.float64) / temperature
+    # Subtract max for numerical stability before exponentiation.
+    scaled -= scaled.max()
+    exp = np.exp(scaled)
+    return (exp / exp.sum()).astype(np.float32)
+
+
+def top_k_filter(probs: np.ndarray, k: int) -> np.ndarray:
+    """Keep the top ``k`` probabilities; zero the rest; renormalise.
+
+    Ties at the k-th position are broken by lowest index (stable).
+    """
+    if k <= 0:
+        raise ValueError("k must be >= 1")
+    probs = np.asarray(probs, dtype=np.float32)
+    if k >= probs.size:
+        return probs / probs.sum() if probs.sum() > 0 else probs
+    # argpartition gives unsorted top-k indices in O(n).
+    top_idx = np.argpartition(probs, -k)[-k:]
+    mask = np.zeros_like(probs, dtype=bool)
+    mask[top_idx] = True
+    out = np.where(mask, probs, 0.0).astype(np.float32)
+    total = out.sum()
+    if total > 0:
+        out = out / total
+    return out
+
+
+def top_p_filter(probs: np.ndarray, p: float) -> np.ndarray:
+    """Nucleus (top-p) truncation: smallest set whose cumulative mass ≥ p.
+
+    Always retains at least the argmax — caller can't end up with an empty
+    distribution. Mass outside the nucleus is zeroed and the rest renormalised.
+    """
+    probs = np.asarray(probs, dtype=np.float32)
+    if p >= 1.0:
+        return probs / probs.sum() if probs.sum() > 0 else probs
+    # Sort descending by probability.
+    sorted_idx = np.argsort(probs)[::-1]
+    sorted_probs = probs[sorted_idx]
+    cumulative = np.cumsum(sorted_probs)
+    # Smallest k such that cumulative[k-1] >= p. ``searchsorted(left)`` on the
+    # ascending cumulative returns that k.
+    cutoff = int(np.searchsorted(cumulative, p, side="left")) + 1
+    cutoff = max(cutoff, 1)  # always keep at least the argmax
+    kept_idx = sorted_idx[:cutoff]
+    out = np.zeros_like(probs, dtype=np.float32)
+    out[kept_idx] = probs[kept_idx]
+    total = out.sum()
+    if total > 0:
+        out = out / total
+    return out
+
+
+def apply_mask(
+    probs: np.ndarray,
+    allowed_mask: Optional[np.ndarray] = None,
+) -> np.ndarray:
+    """Zero indices where ``allowed_mask`` is False, then renormalise.
+
+    Raises when the mask zeroes the entire distribution — callers must
+    guarantee at least one allowed index.
+    """
+    probs = np.asarray(probs, dtype=np.float32)
+    if allowed_mask is None:
+        return probs
+    mask = np.asarray(allowed_mask, dtype=bool)
+    if not mask.any():
+        raise ValueError("mask forbids every index; refusing to produce empty distribution")
+    out = np.where(mask, probs, 0.0).astype(np.float32)
+    total = out.sum()
+    if total > 0:
+        out = out / total
+    else:
+        # All allowed entries were zero already — degrade to uniform over allowed set.
+        out = mask.astype(np.float32)
+        out = out / out.sum()
+    return out
+
+
+def greedy_argmax(probs: np.ndarray) -> int:
+    """Deterministic argmax. Ties broken by lowest index.
+
+    No RNG and no system clock — useful for low-jitter scheduling where the
+    same input must always pick the same token.
+    """
+    probs = np.asarray(probs, dtype=np.float32)
+    # np.argmax already returns the lowest index on ties.
+    return int(np.argmax(probs))
+
+
+def sample_from_probs(probs: np.ndarray, rng: np.random.Generator) -> int:
+    """Sample a single index from ``probs`` using the caller's seeded RNG.
+
+    The RNG is threaded explicitly so behaviour is reproducible — passing
+    the same seeded generator twice yields the same draw sequence.
+    """
+    probs = np.asarray(probs, dtype=np.float64)
+    total = probs.sum()
+    if total <= 0:
+        raise ValueError("probability distribution sums to zero")
+    probs = probs / total
+    return int(rng.choice(len(probs), p=probs))

--- a/music_brain/latent/__init__.py
+++ b/music_brain/latent/__init__.py
@@ -1,0 +1,19 @@
+"""Latent-space utilities: normalization, regularization, calibration."""
+
+from music_brain.latent.normalization import (
+    center,
+    clip_norm,
+    l2_normalize,
+    layer_norm,
+    min_max_scale,
+    standardize,
+)
+
+__all__ = [
+    "center",
+    "clip_norm",
+    "l2_normalize",
+    "layer_norm",
+    "min_max_scale",
+    "standardize",
+]

--- a/music_brain/latent/normalization.py
+++ b/music_brain/latent/normalization.py
@@ -1,0 +1,98 @@
+"""Latent-space normalization primitives.
+
+Stateless NumPy helpers for working with embedding vectors and batches:
+unit-length projection, layer-norm, mean-centering, norm clipping, and
+training-time standardization. Used as the shared base for retrieval,
+projection, and calibration layers — keeps every component agreeing on
+the same numerical conventions instead of each rolling its own.
+
+Goal-list ties: Latent normalization and regularization,
+Personalized latent calibration (standardize), Multimodal latent alignment
+(l2_normalize as a shared pre-step).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+_DEFAULT_EPS = 1e-12
+
+
+def l2_normalize(x: np.ndarray, axis: int = -1, eps: float = _DEFAULT_EPS) -> np.ndarray:
+    """Project ``x`` to unit L2 norm along ``axis``.
+
+    Zero-norm vectors are left as zero (no NaN). The output dtype is float32.
+    """
+    x = np.asarray(x, dtype=np.float32)
+    norm = np.linalg.norm(x, axis=axis, keepdims=True)
+    safe = np.where(norm > eps, norm, 1.0)
+    out = (x / safe).astype(np.float32)
+    # Zero-vector inputs stay zero (np.where above kept them as x/1.0 == x == 0).
+    return out
+
+
+def layer_norm(x: np.ndarray, eps: float = 1e-5) -> np.ndarray:
+    """Per-row mean-0, variance-1 normalization (no learned affine).
+
+    Constant rows produce all-zero output instead of NaN.
+    """
+    x = np.asarray(x, dtype=np.float32)
+    mean = x.mean(axis=-1, keepdims=True)
+    var = x.var(axis=-1, keepdims=True)
+    return ((x - mean) / np.sqrt(var + eps)).astype(np.float32)
+
+
+def center(x: np.ndarray, axis: int = -1) -> np.ndarray:
+    """Subtract the per-axis mean. Variance is preserved."""
+    x = np.asarray(x, dtype=np.float32)
+    mean = x.mean(axis=axis, keepdims=True)
+    return (x - mean).astype(np.float32)
+
+
+def clip_norm(x: np.ndarray, max_norm: float, axis: int = -1) -> np.ndarray:
+    """Scale ``x`` down so that ``||x||_2 <= max_norm`` along ``axis``.
+
+    Vectors already within the cap are returned unchanged. Zero vectors
+    pass through unchanged (no NaN).
+    """
+    if max_norm <= 0.0:
+        raise ValueError("max_norm must be > 0")
+    x = np.asarray(x, dtype=np.float32)
+    norm = np.linalg.norm(x, axis=axis, keepdims=True)
+    # Scale factor: min(1, max_norm/norm); zero-norm becomes 1 (no scaling).
+    safe = np.where(norm > 0, norm, 1.0)
+    scale = np.minimum(1.0, max_norm / safe)
+    return (x * scale).astype(np.float32)
+
+
+def min_max_scale(x: np.ndarray, eps: float = _DEFAULT_EPS) -> np.ndarray:
+    """Linearly rescale to ``[0, 1]`` across the entire array.
+
+    Constant input (max == min) returns zeros.
+    """
+    x = np.asarray(x, dtype=np.float32)
+    lo = x.min()
+    hi = x.max()
+    span = hi - lo
+    if span < eps:
+        return np.zeros_like(x, dtype=np.float32)
+    return ((x - lo) / span).astype(np.float32)
+
+
+def standardize(
+    x: np.ndarray,
+    mean: np.ndarray,
+    std: np.ndarray,
+    eps: float = 1e-6,
+) -> np.ndarray:
+    """Apply ``(x - mean) / std`` using caller-supplied training statistics.
+
+    Zero-std features fall back to a small epsilon so the operation never
+    produces NaN — useful for features that were constant in the training
+    set but might vary at inference.
+    """
+    x = np.asarray(x, dtype=np.float32)
+    mean = np.asarray(mean, dtype=np.float32)
+    std = np.asarray(std, dtype=np.float32)
+    safe_std = np.where(std > eps, std, eps)
+    return ((x - mean) / safe_std).astype(np.float32)

--- a/tests/unit/test_audio_chunking.py
+++ b/tests/unit/test_audio_chunking.py
@@ -1,0 +1,140 @@
+"""Audio chunking primitives (Goal: Streaming audio chunking,
+Chunked latent prediction, Incremental decoding pipeline)."""
+
+import numpy as np
+import pytest
+
+from music_brain.audio.chunking import (
+    WindowedOverlapAdd,
+    iter_chunks,
+    overlap_add,
+    pad_to_chunk_boundary,
+)
+
+
+# ---------------------------------------------------------------------------
+# iter_chunks
+# ---------------------------------------------------------------------------
+
+
+def test_iter_chunks_non_overlapping_covers_whole_signal():
+    signal = np.arange(16, dtype=np.float32)
+    chunks = list(iter_chunks(signal, chunk_size=4, hop_size=4))
+    assert len(chunks) == 4
+    assert chunks[0].tolist() == [0, 1, 2, 3]
+    assert chunks[-1].tolist() == [12, 13, 14, 15]
+
+
+def test_iter_chunks_with_overlap_yields_overlapping_chunks():
+    signal = np.arange(10, dtype=np.float32)
+    chunks = list(iter_chunks(signal, chunk_size=4, hop_size=2))
+    # Starts: 0, 2, 4, 6 → last full chunk starts at 6 (covers 6..9).
+    assert [c[0] for c in chunks] == [0, 2, 4, 6]
+    assert chunks[0].tolist() == [0, 1, 2, 3]
+    assert chunks[1].tolist() == [2, 3, 4, 5]
+
+
+def test_iter_chunks_drops_trailing_partial_when_not_padded():
+    signal = np.arange(10, dtype=np.float32)
+    chunks = list(iter_chunks(signal, chunk_size=4, hop_size=4))
+    # 10 / 4 = 2 full chunks; samples 8-9 dropped (no partial chunks by default).
+    assert len(chunks) == 2
+    assert chunks[-1].tolist() == [4, 5, 6, 7]
+
+
+def test_iter_chunks_invalid_params_raise():
+    signal = np.zeros(8, dtype=np.float32)
+    with pytest.raises(ValueError):
+        list(iter_chunks(signal, chunk_size=0, hop_size=4))
+    with pytest.raises(ValueError):
+        list(iter_chunks(signal, chunk_size=4, hop_size=0))
+
+
+# ---------------------------------------------------------------------------
+# pad_to_chunk_boundary
+# ---------------------------------------------------------------------------
+
+
+def test_pad_to_chunk_boundary_zero_extends_to_multiple_of_chunk_size():
+    signal = np.arange(10, dtype=np.float32)
+    padded = pad_to_chunk_boundary(signal, chunk_size=4, mode="zero")
+    assert padded.shape == (12,)
+    assert padded[10] == 0.0
+    assert padded[11] == 0.0
+    assert padded[:10].tolist() == signal.tolist()
+
+
+def test_pad_to_chunk_boundary_no_op_when_already_aligned():
+    signal = np.arange(8, dtype=np.float32)
+    padded = pad_to_chunk_boundary(signal, chunk_size=4, mode="zero")
+    assert padded is signal or padded.shape == signal.shape
+    assert padded.tolist() == signal.tolist()
+
+
+def test_pad_to_chunk_boundary_reflect_mode():
+    """``reflect`` pads by mirroring the tail."""
+    signal = np.array([1, 2, 3, 4, 5, 6], dtype=np.float32)
+    padded = pad_to_chunk_boundary(signal, chunk_size=4, mode="reflect")
+    assert padded.shape == (8,)
+    # Last two samples should mirror samples 5 and 4 (reverse order):
+    #   [1, 2, 3, 4, 5, 6, 5, 4]
+    assert padded[6] == 5.0
+    assert padded[7] == 4.0
+
+
+# ---------------------------------------------------------------------------
+# overlap_add (stateless)
+# ---------------------------------------------------------------------------
+
+
+def test_overlap_add_inverts_non_overlapping_chunks():
+    signal = np.arange(12, dtype=np.float32)
+    chunks = list(iter_chunks(signal, chunk_size=4, hop_size=4))
+    out = overlap_add(chunks, hop_size=4)
+    assert out.tolist() == signal.tolist()
+
+
+def test_overlap_add_sums_overlapping_regions():
+    """Two unit-valued chunks of length 4 with hop 2 → centre region has value 2."""
+    chunks = [np.ones(4, dtype=np.float32), np.ones(4, dtype=np.float32)]
+    out = overlap_add(chunks, hop_size=2)
+    # Layout: [1, 1, 2, 2, 1, 1]
+    assert out.tolist() == [1.0, 1.0, 2.0, 2.0, 1.0, 1.0]
+
+
+# ---------------------------------------------------------------------------
+# WindowedOverlapAdd (stateful streaming)
+# ---------------------------------------------------------------------------
+
+
+def test_windowed_overlap_add_emits_consistent_hop_size_blocks():
+    """Stateful streaming OLA: each push(chunk) returns hop_size samples
+    of finalized output."""
+    chunk_size = 4
+    hop_size = 2
+    ola = WindowedOverlapAdd(chunk_size=chunk_size, hop_size=hop_size)
+    # Push four unit-valued chunks; each should produce ``hop_size`` samples
+    # of fully overlapped output (=2 after the first one steady-states).
+    outputs = []
+    for _ in range(4):
+        block = ola.push(np.ones(chunk_size, dtype=np.float32))
+        outputs.append(block)
+    # First push has nothing fully overlapped yet → returns hop_size samples
+    # of the leading chunk (value 1.0).
+    assert len(outputs[0]) == hop_size
+    # Subsequent pushes have a second chunk overlapping → value 2.0.
+    assert outputs[1].tolist() == [2.0, 2.0]
+    assert outputs[2].tolist() == [2.0, 2.0]
+
+
+def test_windowed_overlap_add_flush_emits_remaining_tail():
+    """flush() returns whatever is still in the buffer at end of stream."""
+    chunk_size = 4
+    hop_size = 2
+    ola = WindowedOverlapAdd(chunk_size=chunk_size, hop_size=hop_size)
+    ola.push(np.ones(chunk_size, dtype=np.float32))
+    ola.push(np.ones(chunk_size, dtype=np.float32))
+    tail = ola.flush()
+    # After 2 pushes and 2 emits of hop_size, there are chunk_size - hop_size
+    # = 2 samples of overlap left in buffer.
+    assert len(tail) == chunk_size - hop_size

--- a/tests/unit/test_constrained_decoding.py
+++ b/tests/unit/test_constrained_decoding.py
@@ -1,0 +1,196 @@
+"""Constrained decoding primitives (Goal: Constraint-based decoding,
+Top-k/top-p constrained decoding, Greedy low-jitter decoding,
+Constraint-aware generation)."""
+
+import numpy as np
+import pytest
+
+from music_brain.decoding.constrained import (
+    apply_mask,
+    apply_temperature,
+    greedy_argmax,
+    sample_from_probs,
+    top_k_filter,
+    top_p_filter,
+)
+
+
+# ---------------------------------------------------------------------------
+# apply_temperature
+# ---------------------------------------------------------------------------
+
+
+def test_temperature_one_returns_softmax_unchanged():
+    logits = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+    probs = apply_temperature(logits, temperature=1.0)
+    expected = np.exp(logits) / np.exp(logits).sum()
+    assert probs == pytest.approx(expected, abs=1e-6)
+    assert probs.sum() == pytest.approx(1.0)
+
+
+def test_temperature_below_one_sharpens_distribution():
+    logits = np.array([1.0, 2.0], dtype=np.float32)
+    cold = apply_temperature(logits, temperature=0.1)
+    warm = apply_temperature(logits, temperature=1.0)
+    # Cold (low temperature) → concentrates mass on the argmax.
+    assert cold[1] > warm[1]
+
+
+def test_temperature_above_one_flattens_distribution():
+    logits = np.array([1.0, 2.0], dtype=np.float32)
+    hot = apply_temperature(logits, temperature=10.0)
+    base = apply_temperature(logits, temperature=1.0)
+    # Hot → spreads mass; argmax delta shrinks vs uniform.
+    assert (hot[1] - hot[0]) < (base[1] - base[0])
+
+
+def test_temperature_zero_raises():
+    """Temperature 0 is greedy — caller should use greedy_argmax directly."""
+    with pytest.raises(ValueError, match="temperature"):
+        apply_temperature(np.array([1.0, 2.0]), temperature=0.0)
+
+
+# ---------------------------------------------------------------------------
+# top_k_filter
+# ---------------------------------------------------------------------------
+
+
+def test_top_k_zeros_out_low_probability_indices():
+    probs = np.array([0.1, 0.4, 0.2, 0.3], dtype=np.float32)
+    filtered = top_k_filter(probs, k=2)
+    # Keeps indices 1 (0.4) and 3 (0.3); 0 and 2 → 0.
+    assert filtered[0] == 0.0
+    assert filtered[2] == 0.0
+    assert filtered[1] > 0.0
+    assert filtered[3] > 0.0
+    # Renormalised.
+    assert filtered.sum() == pytest.approx(1.0)
+
+
+def test_top_k_with_k_equal_to_length_returns_unchanged():
+    probs = np.array([0.25, 0.25, 0.25, 0.25], dtype=np.float32)
+    filtered = top_k_filter(probs, k=4)
+    assert filtered == pytest.approx(probs)
+
+
+def test_top_k_k_one_returns_argmax_only():
+    probs = np.array([0.1, 0.4, 0.2, 0.3], dtype=np.float32)
+    filtered = top_k_filter(probs, k=1)
+    assert filtered[1] == pytest.approx(1.0)
+    assert sum(p for p in filtered if p > 0) == pytest.approx(1.0)
+    assert int(np.argmax(filtered)) == 1
+
+
+def test_top_k_zero_raises():
+    with pytest.raises(ValueError, match="k"):
+        top_k_filter(np.array([0.5, 0.5]), k=0)
+
+
+# ---------------------------------------------------------------------------
+# top_p_filter (nucleus)
+# ---------------------------------------------------------------------------
+
+
+def test_top_p_keeps_smallest_set_summing_above_p():
+    probs = np.array([0.5, 0.3, 0.15, 0.05], dtype=np.float32)
+    # p=0.7 → cumulative {0.5, 0.8} crosses on the 2nd → keep top 2.
+    filtered = top_p_filter(probs, p=0.7)
+    assert filtered[2] == 0.0
+    assert filtered[3] == 0.0
+    assert filtered[0] > 0.0
+    assert filtered[1] > 0.0
+    assert filtered.sum() == pytest.approx(1.0)
+
+
+def test_top_p_one_keeps_everything():
+    probs = np.array([0.5, 0.3, 0.15, 0.05], dtype=np.float32)
+    filtered = top_p_filter(probs, p=1.0)
+    assert filtered == pytest.approx(probs)
+
+
+def test_top_p_low_p_still_keeps_at_least_one():
+    """Even p=0.01 must keep the argmax — no empty distribution."""
+    probs = np.array([0.5, 0.3, 0.15, 0.05], dtype=np.float32)
+    filtered = top_p_filter(probs, p=0.01)
+    assert filtered[0] == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# apply_mask
+# ---------------------------------------------------------------------------
+
+
+def test_apply_mask_zeros_forbidden_indices_and_renormalises():
+    probs = np.array([0.4, 0.3, 0.2, 0.1], dtype=np.float32)
+    allowed = np.array([True, False, True, True])
+    filtered = apply_mask(probs, allowed_mask=allowed)
+    assert filtered[1] == 0.0
+    assert filtered.sum() == pytest.approx(1.0)
+
+
+def test_apply_mask_all_forbidden_raises():
+    probs = np.array([0.5, 0.5], dtype=np.float32)
+    with pytest.raises(ValueError, match="mask"):
+        apply_mask(probs, allowed_mask=np.array([False, False]))
+
+
+def test_apply_mask_passthrough_when_mask_is_none():
+    probs = np.array([0.5, 0.5], dtype=np.float32)
+    assert apply_mask(probs, allowed_mask=None) == pytest.approx(probs)
+
+
+# ---------------------------------------------------------------------------
+# greedy_argmax (deterministic, low-jitter)
+# ---------------------------------------------------------------------------
+
+
+def test_greedy_argmax_returns_max_index():
+    probs = np.array([0.1, 0.7, 0.2], dtype=np.float32)
+    assert greedy_argmax(probs) == 1
+
+
+def test_greedy_argmax_breaks_ties_with_lowest_index():
+    """Determinism guarantee: equal probs → lowest index. No RNG."""
+    probs = np.array([0.5, 0.5, 0.0], dtype=np.float32)
+    assert greedy_argmax(probs) == 0
+
+
+# ---------------------------------------------------------------------------
+# sample_from_probs (seeded)
+# ---------------------------------------------------------------------------
+
+
+def test_sample_from_probs_is_deterministic_with_seed():
+    probs = np.array([0.2, 0.3, 0.5], dtype=np.float32)
+    rng_a = np.random.default_rng(42)
+    rng_b = np.random.default_rng(42)
+    seq_a = [sample_from_probs(probs, rng_a) for _ in range(20)]
+    seq_b = [sample_from_probs(probs, rng_b) for _ in range(20)]
+    assert seq_a == seq_b
+
+
+def test_sample_from_probs_respects_distribution():
+    """Over many draws, frequencies approximate the input probs."""
+    probs = np.array([0.1, 0.7, 0.2], dtype=np.float32)
+    rng = np.random.default_rng(0)
+    draws = np.array([sample_from_probs(probs, rng) for _ in range(2000)])
+    freq = np.array([np.mean(draws == i) for i in range(len(probs))])
+    assert freq == pytest.approx(probs, abs=0.05)
+
+
+# ---------------------------------------------------------------------------
+# Composed pipeline: temperature → top_p → mask → sample
+# ---------------------------------------------------------------------------
+
+
+def test_composed_pipeline_respects_mask_after_topk_topp():
+    """A token zeroed by mask never appears in samples, even if it survived top_k."""
+    logits = np.array([3.0, 2.0, 1.5, 1.0], dtype=np.float32)
+    probs = apply_temperature(logits, temperature=1.0)
+    probs = top_k_filter(probs, k=3)
+    probs = top_p_filter(probs, p=0.95)
+    # Forbid index 0 (which would otherwise dominate).
+    probs = apply_mask(probs, allowed_mask=np.array([False, True, True, True]))
+    rng = np.random.default_rng(1)
+    draws = [sample_from_probs(probs, rng) for _ in range(500)]
+    assert 0 not in set(draws)

--- a/tests/unit/test_latent_normalization.py
+++ b/tests/unit/test_latent_normalization.py
@@ -1,0 +1,139 @@
+"""Latent normalization primitives (Goal: Latent normalization and regularization,
+Personalized latent calibration, Multimodal latent alignment)."""
+
+import numpy as np
+import pytest
+
+from music_brain.latent.normalization import (
+    center,
+    clip_norm,
+    l2_normalize,
+    layer_norm,
+    min_max_scale,
+    standardize,
+)
+
+
+# ---------------------------------------------------------------------------
+# l2_normalize
+# ---------------------------------------------------------------------------
+
+
+def test_l2_normalize_vector_to_unit_length():
+    v = np.array([3.0, 4.0], dtype=np.float32)  # length 5
+    out = l2_normalize(v)
+    assert np.linalg.norm(out) == pytest.approx(1.0)
+    assert out == pytest.approx([0.6, 0.8])
+
+
+def test_l2_normalize_batch_per_row():
+    batch = np.array([[3.0, 4.0], [1.0, 0.0]], dtype=np.float32)
+    out = l2_normalize(batch, axis=-1)
+    assert np.linalg.norm(out, axis=-1) == pytest.approx([1.0, 1.0])
+
+
+def test_l2_normalize_zero_vector_returns_zero():
+    """An all-zero vector has no direction — return as-is, not NaN."""
+    v = np.zeros(4, dtype=np.float32)
+    out = l2_normalize(v)
+    assert np.all(out == 0.0)
+
+
+# ---------------------------------------------------------------------------
+# layer_norm
+# ---------------------------------------------------------------------------
+
+
+def test_layer_norm_zero_mean_unit_variance_per_row():
+    x = np.array([[1.0, 2.0, 3.0, 4.0]], dtype=np.float32)
+    out = layer_norm(x)
+    assert out.mean(axis=-1) == pytest.approx([0.0], abs=1e-5)
+    assert out.std(axis=-1) == pytest.approx([1.0], abs=1e-4)
+
+
+def test_layer_norm_constant_row_returns_zeros():
+    """All-same input → variance 0 → eps prevents div-by-zero, output ≈ 0."""
+    x = np.array([[5.0, 5.0, 5.0]], dtype=np.float32)
+    out = layer_norm(x, eps=1e-5)
+    assert out == pytest.approx(np.zeros((1, 3)), abs=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# center
+# ---------------------------------------------------------------------------
+
+
+def test_center_subtracts_per_row_mean():
+    x = np.array([[1.0, 2.0, 3.0], [10.0, 20.0, 30.0]], dtype=np.float32)
+    out = center(x, axis=-1)
+    assert out.mean(axis=-1) == pytest.approx([0.0, 0.0])
+    # Original variance preserved.
+    assert out[0] == pytest.approx([-1.0, 0.0, 1.0])
+
+
+# ---------------------------------------------------------------------------
+# clip_norm
+# ---------------------------------------------------------------------------
+
+
+def test_clip_norm_scales_long_vector_down():
+    v = np.array([6.0, 8.0], dtype=np.float32)  # length 10
+    out = clip_norm(v, max_norm=5.0)
+    assert np.linalg.norm(out) == pytest.approx(5.0)
+    # Direction preserved.
+    assert out == pytest.approx([3.0, 4.0])
+
+
+def test_clip_norm_leaves_short_vector_untouched():
+    v = np.array([1.0, 2.0], dtype=np.float32)
+    out = clip_norm(v, max_norm=10.0)
+    assert out == pytest.approx(v)
+
+
+def test_clip_norm_zero_vector_returns_zero():
+    v = np.zeros(3, dtype=np.float32)
+    out = clip_norm(v, max_norm=1.0)
+    assert np.all(out == 0.0)
+
+
+# ---------------------------------------------------------------------------
+# min_max_scale
+# ---------------------------------------------------------------------------
+
+
+def test_min_max_scale_to_unit_interval():
+    x = np.array([1.0, 3.0, 5.0], dtype=np.float32)
+    out = min_max_scale(x)
+    assert out.min() == pytest.approx(0.0)
+    assert out.max() == pytest.approx(1.0)
+    assert out[1] == pytest.approx(0.5)
+
+
+def test_min_max_scale_constant_input_returns_zeros():
+    x = np.array([7.0, 7.0, 7.0], dtype=np.float32)
+    out = min_max_scale(x)
+    assert np.all(out == 0.0)
+
+
+# ---------------------------------------------------------------------------
+# standardize (training-time mean/std applied at inference)
+# ---------------------------------------------------------------------------
+
+
+def test_standardize_uses_provided_mean_and_std():
+    """Reusing training-time statistics at inference: x' = (x - mean) / std."""
+    mean = np.array([1.0, 2.0], dtype=np.float32)
+    std = np.array([0.5, 2.0], dtype=np.float32)
+    x = np.array([[1.5, 4.0], [1.0, 0.0]], dtype=np.float32)
+    out = standardize(x, mean=mean, std=std)
+    assert out[0] == pytest.approx([1.0, 1.0])
+    assert out[1] == pytest.approx([0.0, -1.0])
+
+
+def test_standardize_zero_std_falls_back_to_eps():
+    """A feature with zero training-time std (constant) should not produce NaN."""
+    mean = np.array([1.0, 2.0], dtype=np.float32)
+    std = np.array([0.0, 2.0], dtype=np.float32)
+    x = np.array([[1.5, 4.0]], dtype=np.float32)
+    out = standardize(x, mean=mean, std=std)
+    assert np.all(np.isfinite(out))


### PR DESCRIPTION
## Summary

Three library-agnostic NumPy toolkits that compose into the ML/AI generation stack — no model-runtime coupling, deterministic with caller-provided RNG, full TDD.

Advances the AI/ML goal list along ten items:
- **Constraint-based decoding** + **Top-k/top-p constrained decoding** + **Greedy low-jitter decoding** + **Constraint-aware generation** (primitives)
- **Latent normalization and regularization** + **Personalized latent calibration** (\`standardize\`) + **Multimodal latent alignment** (\`l2_normalize\`)
- **Streaming audio chunking** + **Chunked latent prediction** (prerequisite) + **Incremental decoding pipeline** (prerequisite)

## (1) Constrained decoding — \`music_brain/decoding/constrained.py\`

\`apply_temperature\`, \`top_k_filter\`, \`top_p_filter\`, \`apply_mask\`, \`greedy_argmax\`, \`sample_from_probs\`.

- Numerically stable softmax; refuses T=0.
- O(n) top-k via argpartition; ties → lowest index.
- Top-p always retains at least the argmax.
- Mask raises if it would zero everything.
- Greedy/sample share the same probability-array contract; sampling uses a caller-provided RNG.

## (2) Latent normalization — \`music_brain/latent/normalization.py\`

\`l2_normalize\`, \`layer_norm\`, \`center\`, \`clip_norm\`, \`min_max_scale\`, \`standardize\`.

Every function has a NaN-safe contract for degenerate inputs (zero vector, constant row, zero std, constant input).

## (3) Audio chunking — \`music_brain/audio/chunking.py\`

\`iter_chunks\`, \`pad_to_chunk_boundary\` (\`zero\`/\`reflect\`), \`overlap_add\`, \`WindowedOverlapAdd\` (stateful streaming).

\`WindowedOverlapAdd.push(chunk)\` emits ``hop_size`` finalized samples per chunk and ``flush()`` drains the tail at end of stream — constant-buffer, allocation-light.

## Tests

43 new TDD-driven tests:
- \`test_constrained_decoding.py\` — 19
- \`test_latent_normalization.py\` — 13
- \`test_audio_chunking.py\` — 11

## Test plan

- [x] \`pytest tests/unit/test_constrained_decoding.py tests/unit/test_latent_normalization.py tests/unit/test_audio_chunking.py\` — 43/43
- [x] \`pytest tests/unit/\` — all green
- [ ] CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily additive NumPy utilities plus unit tests, with minimal risk of regressions since no existing business logic is modified. Main risk is subtle numerical/edge-case behavior changes for downstream callers adopting these new helpers (e.g., masking/renormalization, padding, and overlap-add assumptions).
> 
> **Overview**
> Adds three new **library-agnostic NumPy toolkits** aimed at streaming generation workflows: audio windowing/reconstruction utilities (`iter_chunks`, `pad_to_chunk_boundary`, `overlap_add`, `WindowedOverlapAdd`), constraint-aware decoding helpers (temperature softmax, top-k/top-p filtering, allow/forbid masking, greedy selection, seeded sampling), and latent normalization primitives (`l2_normalize`, `layer_norm`, `center`, `clip_norm`, `min_max_scale`, `standardize`).
> 
> Exposes the decoding and latent APIs via new package `__init__.py` re-exports, and introduces comprehensive unit tests covering edge cases (invalid parameters, renormalization behavior, determinism with seeded RNG, and streaming overlap-add flushing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79a0207f2bef8d77e4c54a2217b3835e5a5285eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->