### PR TITLE
feat(generation): GenerationScope + LatencyBudget — RT orchestration primitives

### DIFF
--- a/music_brain/generation/__init__.py
+++ b/music_brain/generation/__init__.py
@@ -1,0 +1,5 @@
+"""Generation orchestration: scopes, isolation, rollback."""
+
+from music_brain.generation.scope import GenerationScope, RollbackError
+
+__all__ = ["GenerationScope", "RollbackError"]

--- a/music_brain/generation/__init__.py
+++ b/music_brain/generation/__init__.py
@@ -1,5 +1,11 @@
-"""Generation orchestration: scopes, isolation, rollback."""
+"""Generation orchestration: scopes, isolation, rollback, latency budgets."""
 
+from music_brain.generation.latency_budget import BudgetExceeded, LatencyBudget
 from music_brain.generation.scope import GenerationScope, RollbackError
 
-__all__ = ["GenerationScope", "RollbackError"]
+__all__ = [
+    "BudgetExceeded",
+    "GenerationScope",
+    "LatencyBudget",
+    "RollbackError",
+]

--- a/music_brain/generation/latency_budget.py
+++ b/music_brain/generation/latency_budget.py
@@ -1,0 +1,91 @@
+"""LatencyBudget — wall-clock + manual-consumption time tracking for
+realtime-ish generation paths.
+
+Pairs a monotonic wall clock with explicit ``consume_ms()`` calls so
+generators can answer two questions cheaply:
+
+  - "Do I have time to run this stage?" → :meth:`has_budget`
+  - "Am I out of time?" → :meth:`is_exhausted` / :attr:`remaining_ms`
+
+The class does *not* enforce real-time deadlines on its own — it's a
+bookkeeping primitive. Callers decide what to skip, retry, or fall back
+to when ``has_budget`` says no.
+
+Goal-list ties: Dynamic latency budgeting (direct),
+Sub-16ms inference targets (callers can gate stages on the remaining
+budget), Low-jitter scheduling (deterministic decision points instead of
+arbitrary timeouts).
+
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+import time
+
+
+class BudgetExceeded(Exception):
+    """Raised by :meth:`LatencyBudget.consume_or_raise` when a step would
+    push consumed-plus-elapsed past the total budget."""
+
+
+class LatencyBudget:
+    """Track remaining budget = ``total - (elapsed + consumed)``.
+
+    ``elapsed_ms`` is measured against a monotonic clock at construction;
+    ``consumed_ms`` is incremented by explicit :meth:`consume_ms` calls so
+    callers can amortise budget across stages that don't run end-to-end
+    against the wall clock.
+    """
+
+    def __init__(self, total_ms: float) -> None:
+        if total_ms <= 0:
+            raise ValueError("total_ms must be > 0")
+        self._total_ms = float(total_ms)
+        self._start = time.monotonic()
+        self._consumed_ms = 0.0
+
+    @property
+    def total_ms(self) -> float:
+        return self._total_ms
+
+    @property
+    def elapsed_ms(self) -> float:
+        return (time.monotonic() - self._start) * 1000.0
+
+    @property
+    def consumed_ms(self) -> float:
+        return self._consumed_ms
+
+    @property
+    def remaining_ms(self) -> float:
+        return max(0.0, self._total_ms - self.elapsed_ms - self._consumed_ms)
+
+    @property
+    def is_exhausted(self) -> bool:
+        return self.remaining_ms <= 0.0
+
+    @property
+    def fraction_used(self) -> float:
+        """``(elapsed + consumed) / total``, clamped to ``[0, 1]``."""
+        used = (self.elapsed_ms + self._consumed_ms) / self._total_ms
+        return min(1.0, max(0.0, used))
+
+    def has_budget(self, required_ms: float) -> bool:
+        """True iff a step claiming ``required_ms`` would still fit."""
+        return required_ms <= self.remaining_ms
+
+    def consume_ms(self, ms: float) -> None:
+        """Add ``ms`` to the manually consumed total."""
+        if ms < 0:
+            raise ValueError("ms must be >= 0")
+        self._consumed_ms += float(ms)
+
+    def consume_or_raise(self, ms: float) -> None:
+        """Consume ``ms`` only if it fits; otherwise raise :class:`BudgetExceeded`."""
+        if not self.has_budget(ms):
+            raise BudgetExceeded(
+                f"requested {ms:.2f}ms but only {self.remaining_ms:.2f}ms left "
+                f"of {self._total_ms:.2f}ms budget"
+            )
+        self.consume_ms(ms)

--- a/music_brain/generation/scope.py
+++ b/music_brain/generation/scope.py
@@ -1,0 +1,119 @@
+"""GenerationScope — sandboxed mutation with explicit commit / rollback.
+
+Wraps a mutable state dict in a ``with``-block. Inside the block, every
+mutation lives on a deep-copied snapshot; the parent dict is only touched
+when the caller explicitly calls :meth:`GenerationScope.commit`. Any
+exception inside the block rolls back even if :meth:`commit` was called —
+the rollback semantics intentionally win over commit on the error path,
+so "audition this regeneration" code can't accidentally leak a partial
+mutation when it crashes mid-way.
+
+Goal-list ties:
+  - Generation scope isolation (direct).
+  - Realtime audition-safe regeneration (the primitive enabling it).
+  - Realtime rollback system (rollback semantics).
+
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Dict
+
+
+class RollbackError(Exception):
+    """Misuse: committing after rollback / committing twice / committing
+    after the scope has closed."""
+
+
+class GenerationScope:
+    """Sandbox a mutable state dict for trial-and-error generation.
+
+    Usage::
+
+        with GenerationScope(state) as scope:
+            scope.state["chord"] = "F"
+            if happy_with_it:
+                scope.commit()
+            # otherwise: implicit rollback on exit
+
+    Default behaviour is *rollback*; the caller must explicitly call
+    :meth:`commit` to keep the changes. If the body raises, rollback wins
+    even when ``commit()`` was already invoked.
+    """
+
+    def __init__(self, parent: Dict[str, Any]) -> None:
+        self._parent = parent
+        self._snapshot: Dict[str, Any] | None = None
+        # Captured at commit() time so post-commit in-scope mutations don't
+        # leak into the parent on __exit__.
+        self._commit_state: Dict[str, Any] | None = None
+        self._committed = False
+        self._closed = False
+        self._active = False
+
+    @property
+    def is_active(self) -> bool:
+        """True while the ``with`` block is running."""
+        return self._active
+
+    @property
+    def has_committed(self) -> bool:
+        """True after :meth:`commit` has been called (still True post-exit)."""
+        return self._committed
+
+    @property
+    def state(self) -> Dict[str, Any]:
+        """The mutable in-scope snapshot. Inside the with-block this is the
+        deep-copied working state; outside the block it's a no-op reference."""
+        return self._snapshot if self._snapshot is not None else self._parent
+
+    # ------------------------------------------------------------------ ctx
+    def __enter__(self) -> "GenerationScope":
+        self._snapshot = copy.deepcopy(self._parent)
+        self._committed = False
+        self._active = True
+        self._closed = False
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+        try:
+            if exc_type is not None:
+                # Exception: rollback wins over any prior commit().
+                self._committed = False
+                return False  # re-raise
+            if self._committed and self._commit_state is not None:
+                # Propagate the at-commit-time state to parent. Mutations
+                # after commit() are intentionally invisible.
+                self._parent.clear()
+                self._parent.update(self._commit_state)
+            return False
+        finally:
+            self._active = False
+            self._closed = True
+
+    # ------------------------------------------------------------------ api
+    def commit(self) -> None:
+        """Mark this scope as committing on exit. Idempotent within a single
+        with-block is *not* allowed — call once. Calling after the scope has
+        closed raises :class:`RollbackError`."""
+        if self._closed:
+            raise RollbackError("scope is closed; cannot commit after exit")
+        if self._committed:
+            raise RollbackError("scope has already been committed")
+        self._committed = True
+        # Snapshot the at-commit-time state so mutations after commit()
+        # don't leak into the parent on __exit__.
+        self._commit_state = copy.deepcopy(self._snapshot)
+
+    def rollback(self) -> None:
+        """Explicit rollback. After this, even a later ``commit()`` won't
+        propagate changes (until the with-block exits and a new scope is
+        entered)."""
+        if self._closed:
+            raise RollbackError("scope is closed; cannot rollback after exit")
+        self._committed = False
+        # Re-snapshot from parent so the in-scope state matches the parent
+        # again (the caller may want to keep experimenting).
+        self._snapshot = copy.deepcopy(self._parent)

--- a/tests/unit/test_generation_scope.py
+++ b/tests/unit/test_generation_scope.py
@@ -1,0 +1,164 @@
+"""GenerationScope context manager (Goal: Generation scope isolation,
+Realtime audition-safe regeneration, Realtime rollback system)."""
+
+import pytest
+
+from music_brain.generation.scope import GenerationScope, RollbackError
+
+
+# ---------------------------------------------------------------------------
+# Basic snapshot / commit / rollback
+# ---------------------------------------------------------------------------
+
+
+def test_scope_returns_snapshot_of_state_on_enter():
+    parent = {"chord": "Am", "tempo": 120, "tracks": ["lead", "bass"]}
+    with GenerationScope(parent) as scope:
+        # Inside the scope, mutations to `scope.state` don't reach parent.
+        scope.state["chord"] = "F"
+        scope.state["tracks"].append("pad")
+    # Default exit behaviour is rollback — parent unchanged.
+    assert parent == {"chord": "Am", "tempo": 120, "tracks": ["lead", "bass"]}
+
+
+def test_scope_commit_propagates_changes_to_parent():
+    parent = {"chord": "Am", "tempo": 120}
+    with GenerationScope(parent) as scope:
+        scope.state["chord"] = "F"
+        scope.commit()
+    assert parent == {"chord": "F", "tempo": 120}
+
+
+def test_scope_explicit_rollback_discards_changes():
+    parent = {"chord": "Am"}
+    with GenerationScope(parent) as scope:
+        scope.state["chord"] = "F"
+        scope.rollback()
+    assert parent == {"chord": "Am"}
+
+
+def test_scope_commit_then_mutations_after_commit_dont_propagate():
+    """Once committed, further in-scope mutations don't keep escaping."""
+    parent = {"chord": "Am"}
+    with GenerationScope(parent) as scope:
+        scope.state["chord"] = "F"
+        scope.commit()
+        # Post-commit mutation: should not silently land in parent.
+        scope.state["chord"] = "G"
+    assert parent == {"chord": "F"}
+
+
+# ---------------------------------------------------------------------------
+# Nesting & isolation
+# ---------------------------------------------------------------------------
+
+
+def test_nested_scopes_independent_rollback():
+    parent = {"chord": "Am"}
+    with GenerationScope(parent) as outer:
+        outer.state["chord"] = "Dm"
+        with GenerationScope(outer.state) as inner:
+            inner.state["chord"] = "G"
+            # inner rolls back on exit (default)
+        # outer still sees its own change
+        assert outer.state["chord"] == "Dm"
+        outer.commit()
+    assert parent == {"chord": "Dm"}
+
+
+def test_nested_commit_propagates_to_outer_only():
+    parent = {"chord": "Am"}
+    with GenerationScope(parent) as outer:
+        with GenerationScope(outer.state) as inner:
+            inner.state["chord"] = "G"
+            inner.commit()
+        # outer now sees inner's commit
+        assert outer.state["chord"] == "G"
+        # but parent doesn't until outer commits
+        assert parent["chord"] == "Am"
+        outer.commit()
+    assert parent["chord"] == "G"
+
+
+# ---------------------------------------------------------------------------
+# Exception handling
+# ---------------------------------------------------------------------------
+
+
+def test_exception_inside_scope_triggers_rollback_not_commit():
+    """If the body raises, the scope must roll back even if commit was called."""
+    parent = {"chord": "Am"}
+    with pytest.raises(RuntimeError, match="boom"):
+        with GenerationScope(parent) as scope:
+            scope.state["chord"] = "F"
+            scope.commit()
+            raise RuntimeError("boom")
+    # Auto-rollback wins over an earlier commit.
+    assert parent == {"chord": "Am"}
+
+
+def test_double_commit_raises():
+    """Committing twice is an API misuse."""
+    parent = {"chord": "Am"}
+    with pytest.raises(RollbackError, match="already"):
+        with GenerationScope(parent) as scope:
+            scope.commit()
+            scope.commit()
+
+
+def test_commit_outside_scope_raises():
+    """commit() called after exiting the with-block must error."""
+    parent = {"chord": "Am"}
+    scope = GenerationScope(parent)
+    with scope:
+        pass
+    with pytest.raises(RollbackError, match="closed"):
+        scope.commit()
+
+
+# ---------------------------------------------------------------------------
+# Deep-copy semantics for nested mutables
+# ---------------------------------------------------------------------------
+
+
+def test_deep_copy_prevents_in_place_mutation_of_parent_list():
+    """Mutating a list inside the scope must not touch the parent's list
+    when rollback is the outcome."""
+    parent = {"tracks": ["lead", "bass"]}
+    with GenerationScope(parent) as scope:
+        scope.state["tracks"].append("pad")
+        # No commit → rollback.
+    assert parent["tracks"] == ["lead", "bass"]
+
+
+def test_deep_copy_prevents_in_place_mutation_after_commit_other_keys():
+    """Commit copies its own snapshot into parent, not a shared reference,
+    so further post-commit mutations on the scope's state don't leak."""
+    parent = {"tracks": ["lead", "bass"]}
+    with GenerationScope(parent) as scope:
+        scope.state["tracks"].append("pad")
+        scope.commit()
+        scope.state["tracks"].append("DO_NOT_LEAK")
+    assert parent["tracks"] == ["lead", "bass", "pad"]
+
+
+# ---------------------------------------------------------------------------
+# is_active / has_committed introspection
+# ---------------------------------------------------------------------------
+
+
+def test_scope_is_active_inside_with_block():
+    parent = {"chord": "Am"}
+    scope = GenerationScope(parent)
+    assert scope.is_active is False
+    with scope:
+        assert scope.is_active is True
+    assert scope.is_active is False
+
+
+def test_scope_has_committed_after_explicit_commit():
+    parent = {"chord": "Am"}
+    with GenerationScope(parent) as scope:
+        assert scope.has_committed is False
+        scope.commit()
+        assert scope.has_committed is True

--- a/tests/unit/test_latency_budget.py
+++ b/tests/unit/test_latency_budget.py
@@ -1,0 +1,125 @@
+"""LatencyBudget primitive (Goal: Dynamic latency budgeting,
+Sub-16ms inference targets, Low-jitter scheduling)."""
+
+import time
+
+import pytest
+
+from music_brain.generation.latency_budget import BudgetExceeded, LatencyBudget
+
+
+# ---------------------------------------------------------------------------
+# Basic timing
+# ---------------------------------------------------------------------------
+
+
+def test_budget_remaining_decreases_as_time_passes():
+    budget = LatencyBudget(total_ms=50.0)
+    initial = budget.remaining_ms
+    time.sleep(0.005)
+    later = budget.remaining_ms
+    assert later < initial
+    assert later > 0
+
+
+def test_budget_elapsed_ms_increases_monotonically():
+    budget = LatencyBudget(total_ms=100.0)
+    samples = []
+    for _ in range(3):
+        samples.append(budget.elapsed_ms)
+        time.sleep(0.002)
+    assert samples == sorted(samples)
+    assert samples[-1] > samples[0]
+
+
+# ---------------------------------------------------------------------------
+# has_budget
+# ---------------------------------------------------------------------------
+
+
+def test_has_budget_true_when_required_within_remaining():
+    budget = LatencyBudget(total_ms=50.0)
+    assert budget.has_budget(required_ms=10.0) is True
+
+
+def test_has_budget_false_when_required_exceeds_remaining():
+    budget = LatencyBudget(total_ms=5.0)
+    assert budget.has_budget(required_ms=100.0) is False
+
+
+def test_has_budget_uses_consumed_budget():
+    """Manually consumed budget reduces what's available for has_budget."""
+    budget = LatencyBudget(total_ms=100.0)
+    budget.consume_ms(80.0)
+    # Wall clock barely advanced; consumed reduces remaining further.
+    assert budget.has_budget(required_ms=30.0) is False
+    assert budget.has_budget(required_ms=10.0) is True
+
+
+# ---------------------------------------------------------------------------
+# consume
+# ---------------------------------------------------------------------------
+
+
+def test_consume_ms_reduces_remaining():
+    budget = LatencyBudget(total_ms=100.0)
+    before = budget.remaining_ms
+    budget.consume_ms(20.0)
+    after = budget.remaining_ms
+    assert before - after >= 19.0  # 20 minus wall-clock noise
+
+
+def test_consume_or_raise_passes_when_within_budget():
+    budget = LatencyBudget(total_ms=100.0)
+    budget.consume_or_raise(20.0)
+    assert budget.remaining_ms > 0
+
+
+def test_consume_or_raise_raises_when_over_budget():
+    budget = LatencyBudget(total_ms=10.0)
+    with pytest.raises(BudgetExceeded):
+        budget.consume_or_raise(50.0)
+
+
+# ---------------------------------------------------------------------------
+# is_exhausted
+# ---------------------------------------------------------------------------
+
+
+def test_is_exhausted_false_initially():
+    budget = LatencyBudget(total_ms=100.0)
+    assert budget.is_exhausted is False
+
+
+def test_is_exhausted_true_after_consuming_full_budget():
+    budget = LatencyBudget(total_ms=100.0)
+    budget.consume_ms(100.0)
+    assert budget.is_exhausted is True
+
+
+def test_is_exhausted_true_after_wall_clock_drains_budget():
+    budget = LatencyBudget(total_ms=5.0)
+    time.sleep(0.01)
+    assert budget.is_exhausted is True
+
+
+# ---------------------------------------------------------------------------
+# fraction_used (for adaptive scheduling)
+# ---------------------------------------------------------------------------
+
+
+def test_fraction_used_starts_near_zero():
+    budget = LatencyBudget(total_ms=100.0)
+    assert budget.fraction_used == pytest.approx(0.0, abs=0.01)
+
+
+def test_fraction_used_one_when_exhausted():
+    budget = LatencyBudget(total_ms=10.0)
+    budget.consume_ms(10.0)
+    assert budget.fraction_used >= 1.0
+
+
+def test_fraction_used_clamps_to_one_when_over_budget():
+    budget = LatencyBudget(total_ms=10.0)
+    budget.consume_ms(50.0)
+    assert budget.fraction_used == 1.0


### PR DESCRIPTION
## Summary

Two stdlib-only primitives for realtime-ish generation orchestration in the music brain stack — neither has model-runtime coupling.

Advances six goal-list items:
- **Generation scope isolation**
- **Realtime audition-safe regeneration**
- **Realtime rollback system**
- **Dynamic latency budgeting**
- **Sub-16ms inference targets** (callers can gate stages on remaining budget)
- **Low-jitter scheduling** (deterministic decision points)

## (1) GenerationScope

\`\`\`python
from music_brain.generation import GenerationScope

with GenerationScope(state) as scope:
    scope.state["chord"] = "F"           # working on a deep-copied snapshot
    if happy_with_it:
        scope.commit()                   # propagate to parent on exit
    # otherwise: implicit rollback on exit
\`\`\`

- Default is rollback; explicit \`commit()\` to keep.
- Mutations after \`commit()\` don't leak (snapshot captured at commit time).
- Exceptions roll back even after \`commit()\`.
- Nested scopes are independent.
- \`RollbackError\` on misuse.

## (2) LatencyBudget

\`\`\`python
from music_brain.generation import LatencyBudget

budget = LatencyBudget(total_ms=16.0)
if budget.has_budget(required_ms=4.0):
    expensive_stage()
    budget.consume_ms(4.0)
elif budget.fraction_used > 0.8:
    fall_back_to_cheap_stage()
\`\`\`

Pairs a monotonic wall clock with explicit \`consume_ms()\`:
- \`remaining_ms = total - elapsed - consumed\` (clamped ≥ 0)
- \`is_exhausted\`, \`fraction_used ∈ [0, 1]\`
- \`consume_or_raise(ms)\` for hard gating

## Tests

27 TDD-driven tests across two files:
- \`test_generation_scope.py\` — 13 tests (isolation, commit/rollback, exception-rollback wins, nesting, deep-copy semantics)
- \`test_latency_budget.py\` — 14 tests (wall-clock progression, has_budget, consume/raise, fraction_used clamp)

## Test plan

- [x] \`pytest tests/unit/test_generation_scope.py tests/unit/test_latency_budget.py\` — 27/27
- [ ] CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, stdlib-only primitives with thorough unit tests; main risk is subtle state-copy/commit semantics if adopted by callers, but no existing runtime paths are modified.
> 
> **Overview**
> Adds a new `music_brain.generation` package exporting two primitives for realtime generation orchestration: `GenerationScope` (context-managed sandbox for dict state with explicit `commit()` and rollback-on-exception semantics) and `LatencyBudget` (monotonic wall-clock + manual `consume_ms()` tracking with `BudgetExceeded`).
> 
> Introduces unit test coverage for scope isolation/commit/rollback, nested scope behavior, exception safety, and time-budget accounting (`tests/unit/test_generation_scope.py`, `tests/unit/test_latency_budget.py`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d5bdb578639062452d498146b089a70a09cca45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->