### PR TITLE
feat(prediction): TransitionModel — Markov baseline for sequential prediction

### DIFF
--- a/music_brain/prediction/__init__.py
+++ b/music_brain/prediction/__init__.py
@@ -1,0 +1,5 @@
+"""Sequence-prediction baselines (Markov, n-gram, etc.)."""
+
+from music_brain.prediction.transition import TransitionModel
+
+__all__ = ["TransitionModel"]

--- a/music_brain/prediction/transition.py
+++ b/music_brain/prediction/transition.py
@@ -1,0 +1,134 @@
+"""First-order Markov transition model.
+
+Deterministic baseline for sequential prediction tasks: section transitions,
+chord progressions, groove patterns. ``fit`` counts (state → next_state)
+occurrences across one or more sequences, and the predict / sample methods
+expose the normalised transition distribution.
+
+Used as the floor for any sequential-prediction goal in the music brain
+stack — engineering above this baseline should beat it on held-out data.
+
+Goal-list ties:
+  - Predictive arrangement modeling (section sequences)
+  - Future-state musical prediction (next-state distribution)
+  - Harmony prediction engine (chord transition matrix)
+  - Groove prediction engine (rhythmic pattern transitions)
+
+Stdlib + numpy (for the seeded sampler).
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Dict, Iterable, List, Sequence
+
+import numpy as np
+
+
+class TransitionModel:
+    """First-order Markov transition counts with optional Laplace smoothing.
+
+    Parameters
+    ----------
+    alpha:
+        Laplace pseudo-count added to every (state, next_state) pair before
+        normalisation. ``alpha == 0`` gives plain maximum-likelihood
+        estimates; ``alpha > 0`` assigns nonzero probability to unseen
+        transitions among the observed state set.
+    """
+
+    def __init__(self, alpha: float = 0.0) -> None:
+        if alpha < 0:
+            raise ValueError("alpha must be >= 0")
+        self._alpha = float(alpha)
+        # state -> Counter({next_state: count, ...})
+        self._counts: Dict[str, Counter] = {}
+        self._state_set: set[str] = set()
+
+    @property
+    def states(self) -> List[str]:
+        """Sorted list of observed states (sources or sinks)."""
+        return sorted(self._state_set)
+
+    def fit(self, sequences: Iterable[Sequence[str]]) -> "TransitionModel":
+        """Count transitions across one or more sequences.
+
+        ``fit`` is additive — calling it multiple times accumulates counts
+        rather than resetting. ``reset()`` wipes the model if needed.
+        """
+        for seq in sequences:
+            for i, state in enumerate(seq):
+                self._state_set.add(state)
+                if i + 1 >= len(seq):
+                    continue
+                nxt = seq[i + 1]
+                self._state_set.add(nxt)
+                self._counts.setdefault(state, Counter())[nxt] += 1
+        return self
+
+    def reset(self) -> None:
+        """Drop all accumulated counts."""
+        self._counts.clear()
+        self._state_set.clear()
+
+    def predict_next(self, state: str) -> Dict[str, float]:
+        """Return the next-state probability distribution given ``state``.
+
+        - Returns ``{}`` for states never observed at all.
+        - Returns ``{}`` for states observed only as a terminal (no outgoing
+          edges) unless ``alpha > 0``, in which case smoothing puts mass on
+          every observed state.
+        - With ``alpha > 0``, the support is the full observed state set.
+        """
+        if state not in self._state_set:
+            return {}
+        outgoing = self._counts.get(state, Counter())
+        if not outgoing and self._alpha == 0.0:
+            return {}
+        # With smoothing, candidate set is all observed states.
+        candidates = self._state_set if self._alpha > 0 else set(outgoing)
+        total = sum(outgoing.values()) + self._alpha * len(candidates)
+        if total == 0:
+            return {}
+        return {
+            s: (outgoing.get(s, 0) + self._alpha) / total
+            for s in candidates
+        }
+
+    def sample_next(self, state: str, rng: np.random.Generator) -> str:
+        """Sample one next-state from ``predict_next(state)``.
+
+        Raises ``KeyError`` when ``state`` has no observed transitions and
+        smoothing is disabled.
+        """
+        dist = self.predict_next(state)
+        if not dist:
+            raise KeyError(f"no outgoing transitions from state {state!r}")
+        keys = list(dist.keys())
+        probs = np.array([dist[k] for k in keys], dtype=np.float64)
+        probs = probs / probs.sum()
+        idx = int(rng.choice(len(keys), p=probs))
+        return keys[idx]
+
+    def predict_sequence(
+        self,
+        start: str,
+        length: int,
+        rng: np.random.Generator,
+    ) -> List[str]:
+        """Sample a Markov sequence of ``length`` states starting from ``start``.
+
+        Returns ``[start, ...]``. Terminates early if the chain reaches a
+        state with no outgoing transitions (and no smoothing to fill in).
+        """
+        if length <= 0:
+            return []
+        out = [start]
+        current = start
+        while len(out) < length:
+            try:
+                current = self.sample_next(current, rng)
+            except KeyError:
+                break
+            out.append(current)
+        return out

--- a/tests/unit/test_transition_model.py
+++ b/tests/unit/test_transition_model.py
@@ -1,0 +1,149 @@
+"""TransitionModel — Markov baseline for sequential prediction.
+
+Goal: Predictive arrangement modeling, Future-state musical prediction,
+Harmony prediction engine (chord transitions), Groove prediction engine
+(rhythmic pattern transitions)."""
+
+import numpy as np
+import pytest
+
+from music_brain.prediction.transition import TransitionModel
+
+
+# ---------------------------------------------------------------------------
+# fit
+# ---------------------------------------------------------------------------
+
+
+def test_fit_records_observed_states():
+    model = TransitionModel()
+    model.fit([["intro", "verse", "chorus", "verse", "outro"]])
+    assert model.states == ["chorus", "intro", "outro", "verse"]
+
+
+def test_fit_multiple_sequences_aggregates_counts():
+    model = TransitionModel()
+    model.fit([
+        ["verse", "chorus", "verse", "chorus"],
+        ["intro", "verse", "outro"],
+    ])
+    # Sequences should both contribute to the transition counts.
+    next_dist = model.predict_next("verse")
+    assert next_dist["chorus"] == pytest.approx(2 / 3)
+    assert next_dist["outro"] == pytest.approx(1 / 3)
+
+
+def test_fit_empty_sequences_does_not_crash():
+    model = TransitionModel()
+    model.fit([[]])
+    assert model.states == []
+
+
+def test_fit_singleton_sequence_records_state_but_no_transitions():
+    model = TransitionModel()
+    model.fit([["solo"]])
+    assert model.states == ["solo"]
+    # No outgoing edges from solo.
+    assert model.predict_next("solo") == {}
+
+
+# ---------------------------------------------------------------------------
+# predict_next
+# ---------------------------------------------------------------------------
+
+
+def test_predict_next_returns_probabilities_summing_to_one():
+    model = TransitionModel()
+    model.fit([["a", "b", "a", "c", "a", "b"]])
+    dist = model.predict_next("a")
+    assert sum(dist.values()) == pytest.approx(1.0)
+
+
+def test_predict_next_normalises_by_outgoing_count():
+    model = TransitionModel()
+    # a → b twice, a → c once
+    model.fit([["a", "b", "a", "b", "a", "c"]])
+    dist = model.predict_next("a")
+    assert dist["b"] == pytest.approx(2 / 3)
+    assert dist["c"] == pytest.approx(1 / 3)
+
+
+def test_predict_next_unknown_state_returns_empty_dict():
+    model = TransitionModel()
+    model.fit([["a", "b"]])
+    assert model.predict_next("z") == {}
+
+
+# ---------------------------------------------------------------------------
+# sample_next
+# ---------------------------------------------------------------------------
+
+
+def test_sample_next_returns_observed_successor():
+    model = TransitionModel()
+    model.fit([["a", "b", "a", "b"]])
+    rng = np.random.default_rng(0)
+    for _ in range(20):
+        assert model.sample_next("a", rng) == "b"
+
+
+def test_sample_next_is_deterministic_with_same_seed():
+    model = TransitionModel()
+    model.fit([["a", "b", "a", "c", "a", "d", "a", "b", "a", "c"]])
+    seq1 = [
+        model.sample_next("a", np.random.default_rng(42)) for _ in range(5)
+    ]
+    seq2 = [
+        model.sample_next("a", np.random.default_rng(42)) for _ in range(5)
+    ]
+    assert seq1 == seq2
+
+
+def test_sample_next_unknown_state_raises():
+    model = TransitionModel()
+    model.fit([["a", "b"]])
+    rng = np.random.default_rng(0)
+    with pytest.raises(KeyError):
+        model.sample_next("z", rng)
+
+
+# ---------------------------------------------------------------------------
+# predict_sequence
+# ---------------------------------------------------------------------------
+
+
+def test_predict_sequence_starts_at_given_state_and_runs_length_steps():
+    model = TransitionModel()
+    model.fit([["a", "b", "a", "b", "a", "b"]])
+    rng = np.random.default_rng(0)
+    seq = model.predict_sequence("a", length=5, rng=rng)
+    assert len(seq) == 5
+    assert seq[0] == "a"
+    # Every step after a must be b in this fully deterministic chain.
+    assert all(s in {"a", "b"} for s in seq)
+
+
+def test_predict_sequence_stops_early_at_terminal_state():
+    """If a state has no outgoing transitions, the sequence ends there
+    rather than padding or looping."""
+    model = TransitionModel()
+    model.fit([["a", "b", "outro"]])  # outro is terminal
+    rng = np.random.default_rng(0)
+    seq = model.predict_sequence("a", length=10, rng=rng)
+    assert seq[-1] == "outro"
+    assert len(seq) <= 10
+
+
+# ---------------------------------------------------------------------------
+# Laplace smoothing
+# ---------------------------------------------------------------------------
+
+
+def test_predict_next_with_smoothing_assigns_mass_to_unseen_states():
+    """With alpha smoothing, every known state appears in the distribution."""
+    model = TransitionModel(alpha=1.0)
+    model.fit([["a", "b", "a", "b", "c"]])
+    dist = model.predict_next("a")
+    # Without smoothing, c would have 0 mass from a; with alpha=1 it's nonzero.
+    assert dist["c"] > 0
+    assert sum(dist.values()) == pytest.approx(1.0)


### PR DESCRIPTION
## Summary

A first-order Markov transition model — the deterministic floor baseline for any sequential-prediction task in the music brain stack. Same model class fits section transitions, chord progressions, and groove patterns; engineering above this should beat it on held-out data.

Advances four goal-list items:
- **Predictive arrangement modeling** (section sequences)
- **Future-state musical prediction** (next-state distribution)
- **Harmony prediction engine** (chord transition matrix)
- **Groove prediction engine** (rhythmic pattern transitions)

## API

\`\`\`python
from music_brain.prediction import TransitionModel
import numpy as np

# Fit on past arrangements (additive: call multiple times to accumulate)
model = TransitionModel(alpha=0.0)  # alpha > 0 → Laplace smoothing
model.fit([
    ["intro", "verse", "chorus", "verse", "chorus", "outro"],
    ["intro", "verse", "bridge", "chorus", "outro"],
])

# Predict next-state distribution
model.predict_next("verse")              # {"chorus": 0.67, "bridge": 0.33}

# Sample a single next state (seeded — deterministic)
rng = np.random.default_rng(42)
model.sample_next("verse", rng)          # "chorus"

# Sample a Markov walk; terminates at states with no outgoing edges
model.predict_sequence("intro", length=8, rng=rng)
\`\`\`

## Smoothing

\`alpha=0.0\` gives plain maximum-likelihood (zero mass on unseen transitions); \`alpha > 0\` puts non-zero mass on every observed state, useful for predict-after-sparse-training paths.

## Tests

13 TDD-driven tests in \`tests/unit/test_transition_model.py\`:
- \`fit\`: state aggregation, multi-sequence accumulation, empty sequence safety, singleton sequence
- \`predict_next\`: sum-to-one normalisation, MLE count ratios, unknown-state empty result
- \`sample_next\`: observed successor, seed determinism, terminal-state KeyError
- \`predict_sequence\`: length adherence, early termination on terminal
- Smoothing: unseen states get nonzero mass

## Test plan

- [x] \`pytest tests/unit/test_transition_model.py\` — 13/13
- [ ] CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: new, self-contained prediction module and unit tests with no changes to existing runtime paths; primary risk is minor API/behavior expectations around smoothing and terminal states.
> 
> **Overview**
> Adds a new `music_brain.prediction` package exposing `TransitionModel`, a first-order Markov transition baseline that can `fit` transition counts, return next-state probability distributions (optionally Laplace-smoothed via `alpha`), and sample next states / sequences using a seeded NumPy RNG.
> 
> Introduces a focused unit test suite covering state aggregation, distribution normalisation, deterministic sampling, early termination at terminal states, and smoothing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c423bf8cb45daccbafdef3ca919b569d98ef555a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->