### PR TITLE
feat(audio): StemBus — multi-stem container with mix-down, gain, mute/solo

### DIFF
--- a/music_brain/audio/stems.py
+++ b/music_brain/audio/stems.py
@@ -1,0 +1,107 @@
+"""StemBus — multi-stem audio container with mix-down.
+
+A small DAW-style routing primitive: per-named-stem audio buffers, per-stem
+gain in linear units, mute/solo flags, and ``mix()`` that returns the
+gain-scaled, mute-and-solo-respecting sum. Designed to sit between a
+multi-instrument generator (which emits one buffer per role/patch/instrument)
+and a downstream renderer that expects a single mixed buffer or a stem-set.
+
+Iteration order preserves insertion (matches DAW track-list expectations).
+
+Goal-list ties: Stem-aware generation, Multi-instrument orchestration.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import numpy as np
+
+
+class StemBus:
+    """Multi-stem audio bus indexed by name.
+
+    All stems share a fixed sample length; attempting to set a stem of a
+    different length raises ``ValueError`` so callers can't mix unaligned
+    buffers by accident.
+    """
+
+    def __init__(self, num_samples: int) -> None:
+        if num_samples <= 0:
+            raise ValueError("num_samples must be > 0")
+        self._n = int(num_samples)
+        self._stems: Dict[str, np.ndarray] = {}
+        self._gain: Dict[str, float] = {}
+        self._mute: Dict[str, bool] = {}
+        self._solo: Dict[str, bool] = {}
+
+    # -------------------------------------------------------------- basics
+    @property
+    def num_samples(self) -> int:
+        return self._n
+
+    @property
+    def names(self) -> List[str]:
+        """Stem names in insertion order."""
+        return list(self._stems.keys())
+
+    def set(self, name: str, buffer: np.ndarray) -> None:
+        buf = np.asarray(buffer, dtype=np.float32)
+        if buf.shape != (self._n,):
+            raise ValueError(
+                f"buffer length {buf.shape} != bus length ({self._n},)"
+            )
+        if name not in self._stems:
+            self._gain[name] = 1.0
+            self._mute[name] = False
+            self._solo[name] = False
+        self._stems[name] = buf
+
+    def get(self, name: str) -> np.ndarray:
+        return self._stems[name]
+
+    def remove(self, name: str) -> None:
+        del self._stems[name]
+        self._gain.pop(name, None)
+        self._mute.pop(name, None)
+        self._solo.pop(name, None)
+
+    # ------------------------------------------------------- gain / mute / solo
+    def set_gain(self, name: str, gain: float) -> None:
+        if name not in self._stems:
+            raise KeyError(name)
+        self._gain[name] = float(gain)
+
+    def get_gain(self, name: str) -> float:
+        return self._gain[name]
+
+    def mute(self, name: str, value: bool) -> None:
+        if name not in self._stems:
+            raise KeyError(name)
+        self._mute[name] = bool(value)
+
+    def solo(self, name: str, value: bool) -> None:
+        if name not in self._stems:
+            raise KeyError(name)
+        self._solo[name] = bool(value)
+
+    # -------------------------------------------------------------- mix
+    def mix(self) -> np.ndarray:
+        """Sum all audible stems with their gain applied.
+
+        DAW convention: when any stem is soloed, only soloed stems are
+        audible; mute is ignored on a soloed stem. With no solo active,
+        mute simply excludes the stem.
+        """
+        any_solo = any(self._solo.values())
+        out = np.zeros(self._n, dtype=np.float32)
+        for name, buf in self._stems.items():
+            if any_solo:
+                if not self._solo[name]:
+                    continue
+                # solo overrides mute, so don't check mute here
+            else:
+                if self._mute[name]:
+                    continue
+            out += buf * self._gain[name]
+        return out

--- a/tests/unit/test_stem_bus.py
+++ b/tests/unit/test_stem_bus.py
@@ -1,0 +1,135 @@
+"""StemBus — multi-stem audio container with mix-down and per-stem gain.
+
+Goal: Stem-aware generation, Multi-instrument orchestration."""
+
+import numpy as np
+import pytest
+
+from music_brain.audio.stems import StemBus
+
+
+# ---------------------------------------------------------------------------
+# Construction and assignment
+# ---------------------------------------------------------------------------
+
+
+def test_bus_starts_empty():
+    bus = StemBus(num_samples=64)
+    assert bus.names == []
+    assert bus.mix().tolist() == [0.0] * 64
+
+
+def test_set_stem_stores_buffer():
+    bus = StemBus(num_samples=4)
+    bus.set("drums", np.array([1.0, 1.0, 1.0, 1.0], dtype=np.float32))
+    assert bus.names == ["drums"]
+    np.testing.assert_array_equal(bus.get("drums"), [1.0, 1.0, 1.0, 1.0])
+
+
+def test_set_stem_with_wrong_length_raises():
+    bus = StemBus(num_samples=4)
+    with pytest.raises(ValueError, match="length"):
+        bus.set("drums", np.array([1.0, 1.0], dtype=np.float32))
+
+
+def test_get_unknown_stem_raises():
+    bus = StemBus(num_samples=4)
+    with pytest.raises(KeyError):
+        bus.get("missing")
+
+
+# ---------------------------------------------------------------------------
+# mix() with per-stem gain
+# ---------------------------------------------------------------------------
+
+
+def test_mix_sums_stems():
+    bus = StemBus(num_samples=4)
+    bus.set("a", np.ones(4, dtype=np.float32))
+    bus.set("b", np.ones(4, dtype=np.float32) * 2.0)
+    assert bus.mix().tolist() == [3.0, 3.0, 3.0, 3.0]
+
+
+def test_mix_applies_per_stem_gain():
+    bus = StemBus(num_samples=4)
+    bus.set("a", np.ones(4, dtype=np.float32))
+    bus.set("b", np.ones(4, dtype=np.float32))
+    bus.set_gain("a", 0.5)
+    bus.set_gain("b", 2.0)
+    assert bus.mix().tolist() == [2.5, 2.5, 2.5, 2.5]
+
+
+def test_set_gain_unknown_stem_raises():
+    bus = StemBus(num_samples=4)
+    with pytest.raises(KeyError):
+        bus.set_gain("missing", 1.0)
+
+
+def test_default_gain_is_one():
+    bus = StemBus(num_samples=4)
+    bus.set("a", np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32))
+    assert bus.get_gain("a") == 1.0
+    np.testing.assert_array_equal(bus.mix(), [1.0, 2.0, 3.0, 4.0])
+
+
+# ---------------------------------------------------------------------------
+# mute / solo
+# ---------------------------------------------------------------------------
+
+
+def test_mute_excludes_stem_from_mix():
+    bus = StemBus(num_samples=4)
+    bus.set("a", np.ones(4, dtype=np.float32))
+    bus.set("b", np.ones(4, dtype=np.float32))
+    bus.mute("a", True)
+    assert bus.mix().tolist() == [1.0, 1.0, 1.0, 1.0]
+
+
+def test_unmute_restores_stem():
+    bus = StemBus(num_samples=4)
+    bus.set("a", np.ones(4, dtype=np.float32))
+    bus.mute("a", True)
+    bus.mute("a", False)
+    assert bus.mix().tolist() == [1.0, 1.0, 1.0, 1.0]
+
+
+def test_solo_includes_only_soloed_stems():
+    bus = StemBus(num_samples=4)
+    bus.set("a", np.ones(4, dtype=np.float32))
+    bus.set("b", np.ones(4, dtype=np.float32) * 2.0)
+    bus.set("c", np.ones(4, dtype=np.float32) * 4.0)
+    bus.solo("b", True)
+    # Only b is audible.
+    assert bus.mix().tolist() == [2.0, 2.0, 2.0, 2.0]
+
+
+def test_solo_overrides_mute():
+    bus = StemBus(num_samples=4)
+    bus.set("a", np.ones(4, dtype=np.float32))
+    bus.set("b", np.ones(4, dtype=np.float32) * 3.0)
+    bus.mute("b", True)
+    bus.solo("b", True)
+    # solo wins over mute (DAW convention).
+    assert bus.mix().tolist() == [3.0, 3.0, 3.0, 3.0]
+
+
+# ---------------------------------------------------------------------------
+# Iteration / inspection
+# ---------------------------------------------------------------------------
+
+
+def test_names_preserves_insertion_order():
+    bus = StemBus(num_samples=4)
+    bus.set("b", np.ones(4, dtype=np.float32))
+    bus.set("a", np.ones(4, dtype=np.float32))
+    bus.set("c", np.ones(4, dtype=np.float32))
+    assert bus.names == ["b", "a", "c"]
+
+
+def test_remove_stem_drops_from_mix():
+    bus = StemBus(num_samples=4)
+    bus.set("a", np.ones(4, dtype=np.float32))
+    bus.set("b", np.ones(4, dtype=np.float32) * 2.0)
+    bus.remove("a")
+    assert bus.names == ["b"]
+    assert bus.mix().tolist() == [2.0, 2.0, 2.0, 2.0]


### PR DESCRIPTION
## Summary

A DAW-style routing primitive that sits between a multi-instrument generator and a downstream renderer: per-named-stem audio buffers, per-stem linear gain, mute/solo flags, and \`mix()\` that returns the audible-stem sum.

Advances two goal-list items:
- **Stem-aware generation** (direct)
- **Multi-instrument orchestration** (routing target for generator outputs)

## API

\`\`\`python
from music_brain.audio.stems import StemBus
import numpy as np

bus = StemBus(num_samples=44100)
bus.set("drums", drums_buf)        # length-enforced (raises if mismatched)
bus.set("bass", bass_buf)
bus.set_gain("bass", 0.8)
bus.solo("drums", True)            # solo wins over mute — DAW convention
out = bus.mix()                    # → np.ndarray of length 44100
\`\`\`

DAW conventions implemented:
- **solo overrides mute.** When any stem is soloed, only soloed stems are audible regardless of their mute state.
- **mute simply excludes** when no solo is active.
- **Insertion order preserved** in \`.names\` to match track-list expectations.

## Tests

14 TDD-driven tests in \`tests/unit/test_stem_bus.py\` covering empty bus, length enforcement, default gain (1.0), gain scaling, mute exclude, solo include, solo-overrides-mute, insertion order, and remove dropping from mix.

## Test plan

- [x] \`pytest tests/unit/test_stem_bus.py\` — 14/14
- [ ] CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: isolated new audio utility plus unit tests, with no changes to existing audio rendering or API paths. Main risk is behavioral expectations around solo/mute conventions and strict buffer-length enforcement.
> 
> **Overview**
> Introduces `music_brain.audio.stems.StemBus`, a new multi-stem audio container that enforces a fixed buffer length per bus and provides `mix()` to sum stems with per-stem linear gain plus DAW-style *mute/solo* rules (solo overrides mute when any solo is active).
> 
> Adds a focused `tests/unit/test_stem_bus.py` suite covering construction, length validation, default gain, gain scaling, mute/solo behavior, insertion-order name listing, and stem removal effects on the mix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 274ce5f67668f677b11e08ffb54b12a5533a9be5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->