### PR TITLE
feat(generation): ContextWindow — sliding window with overflow summarisation

### DIFF
--- a/music_brain/generation/__init__.py
+++ b/music_brain/generation/__init__.py
@@ -1,0 +1,5 @@
+"""Generation orchestration: scopes, context windows, latency budgets."""
+
+from music_brain.generation.context_window import ContextEntry, ContextWindow
+
+__all__ = ["ContextEntry", "ContextWindow"]

--- a/music_brain/generation/context_window.py
+++ b/music_brain/generation/context_window.py
@@ -1,0 +1,126 @@
+"""ContextWindow — sliding token-budgeted context with overflow summarisation.
+
+Wraps a token budget around a list of conversational entries (role + text +
+token count). When an append would exceed the budget, the oldest entries
+are popped off and — if a ``summarizer`` callback is configured — passed to
+that callback so their content can be folded into a persistent ``summary``
+prefix instead of being lost outright.
+
+This is the host-side primitive behind "Context persistence beyond token
+window": each step the model gets a ``summary || recent_entries`` view,
+and the summary keeps growing as older context falls off. The summarizer
+itself is the caller's choice — extractive, abstractive, embedding-based,
+or just identity for "remember verbatim".
+
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, List, Optional, Sequence
+
+_VALID_ROLES = frozenset({"system", "user", "assistant", "tool"})
+
+# A summarizer takes (dropped_entries, current_summary) and returns the new summary.
+SummarizerFn = Callable[[Sequence["ContextEntry"], str], str]
+
+
+@dataclass
+class ContextEntry:
+    """One turn in the conversation."""
+
+    role: str
+    text: str
+    tokens: int
+
+    def __post_init__(self) -> None:
+        if self.tokens < 0:
+            raise ValueError("tokens must be >= 0")
+
+
+class ContextWindow:
+    """Sliding-window context with optional overflow summarisation.
+
+    Parameters
+    ----------
+    max_tokens:
+        Soft upper bound on the in-window entries' total token count.
+        Oversized single entries are stored anyway (the alternative is
+        silently dropping caller data); use :meth:`would_fit` to gate
+        appends if that's not acceptable.
+    summarizer:
+        Optional callback invoked with the entries that just fell out of
+        the window plus the current summary; returns the new summary.
+        ``None`` → dropped entries are discarded.
+    """
+
+    def __init__(
+        self,
+        max_tokens: int,
+        summarizer: Optional[SummarizerFn] = None,
+    ) -> None:
+        if max_tokens <= 0:
+            raise ValueError("max_tokens must be > 0")
+        self._max_tokens = int(max_tokens)
+        self._summarizer = summarizer
+        self._entries: List[ContextEntry] = []
+        self._summary = ""
+
+    # -------------------------------------------------------------- inspect
+    @property
+    def entries(self) -> List[ContextEntry]:
+        return list(self._entries)
+
+    @property
+    def summary(self) -> str:
+        return self._summary
+
+    @property
+    def total_tokens(self) -> int:
+        return sum(e.tokens for e in self._entries)
+
+    @property
+    def max_tokens(self) -> int:
+        return self._max_tokens
+
+    def would_fit(self, tokens: int) -> bool:
+        return self.total_tokens + tokens <= self._max_tokens
+
+    # -------------------------------------------------------------- mutate
+    def append(self, entry: ContextEntry) -> None:
+        if entry.role not in _VALID_ROLES:
+            raise ValueError(
+                f"role {entry.role!r} not in {sorted(_VALID_ROLES)}"
+            )
+        self._entries.append(entry)
+        self._evict_until_fits()
+
+    def _evict_until_fits(self) -> None:
+        """Pop oldest entries until the window fits ``max_tokens``.
+
+        A single oversized entry is kept (no entries → would re-evict to
+        empty; we don't drop the just-appended data either).
+        """
+        dropped: List[ContextEntry] = []
+        while (
+            len(self._entries) > 1
+            and sum(e.tokens for e in self._entries) > self._max_tokens
+        ):
+            dropped.append(self._entries.pop(0))
+        if dropped and self._summarizer is not None:
+            self._summary = self._summarizer(dropped, self._summary)
+
+    # -------------------------------------------------------------- render
+    def render(self) -> str:
+        """Render the window as ``summary || recent_entries`` text.
+
+        Format is intentionally minimal — callers will usually replace this
+        with their model-specific chat formatter. Suitable as a smoke check.
+        """
+        lines: List[str] = []
+        if self._summary:
+            lines.append(f"[summary] {self._summary}")
+        for entry in self._entries:
+            lines.append(f"{entry.role}: {entry.text}")
+        return "\n".join(lines)

--- a/tests/unit/test_context_window.py
+++ b/tests/unit/test_context_window.py
@@ -1,0 +1,154 @@
+"""ContextWindow — sliding window with overflow summarisation.
+
+Goal: Context persistence beyond token window."""
+
+import pytest
+
+from music_brain.generation.context_window import ContextEntry, ContextWindow
+
+
+# ---------------------------------------------------------------------------
+# Construction & basic append
+# ---------------------------------------------------------------------------
+
+
+def test_window_starts_empty():
+    win = ContextWindow(max_tokens=100, summarizer=None)
+    assert win.entries == []
+    assert win.summary == ""
+    assert win.total_tokens == 0
+
+
+def test_append_records_entry_under_capacity():
+    win = ContextWindow(max_tokens=100, summarizer=None)
+    win.append(ContextEntry(role="user", text="hello", tokens=10))
+    assert len(win.entries) == 1
+    assert win.entries[0].text == "hello"
+    assert win.total_tokens == 10
+
+
+def test_append_invalid_role_raises():
+    win = ContextWindow(max_tokens=100, summarizer=None)
+    with pytest.raises(ValueError, match="role"):
+        win.append(ContextEntry(role="alien", text="hi", tokens=1))
+
+
+# ---------------------------------------------------------------------------
+# Overflow without summarizer → just drops oldest
+# ---------------------------------------------------------------------------
+
+
+def test_overflow_without_summarizer_drops_oldest():
+    win = ContextWindow(max_tokens=20, summarizer=None)
+    win.append(ContextEntry(role="user", text="first", tokens=10))
+    win.append(ContextEntry(role="assistant", text="second", tokens=10))
+    win.append(ContextEntry(role="user", text="third", tokens=10))
+    # Oldest (first) dropped to fit budget.
+    texts = [e.text for e in win.entries]
+    assert "first" not in texts
+    assert "second" in texts
+    assert "third" in texts
+
+
+# ---------------------------------------------------------------------------
+# Overflow with summarizer → compresses into prefix
+# ---------------------------------------------------------------------------
+
+
+def test_overflow_with_summarizer_compresses_dropped_entries():
+    """Dropped entries get passed to the summarizer; the result becomes the
+    window's `summary` prefix instead of being lost."""
+    received = []
+
+    def summarizer(dropped, current_summary):
+        received.append(dropped)
+        # Trivial: summary is just space-joined texts.
+        prev = current_summary + " | " if current_summary else ""
+        return prev + " ".join(e.text for e in dropped)
+
+    win = ContextWindow(max_tokens=20, summarizer=summarizer)
+    win.append(ContextEntry(role="user", text="first", tokens=10))
+    win.append(ContextEntry(role="assistant", text="second", tokens=10))
+    win.append(ContextEntry(role="user", text="third", tokens=10))
+    # `first` was the one dropped to make room.
+    assert len(received) >= 1
+    flattened_dropped_texts = [e.text for batch in received for e in batch]
+    assert "first" in flattened_dropped_texts
+    assert "first" in win.summary
+
+
+def test_summary_persists_across_multiple_overflows():
+    """Subsequent overflows build on the existing summary, not replace it."""
+
+    def summarizer(dropped, current_summary):
+        # Append-style; never discards what was already summarized.
+        prev = current_summary + " | " if current_summary else ""
+        return prev + " ".join(e.text for e in dropped)
+
+    win = ContextWindow(max_tokens=20, summarizer=summarizer)
+    for i in range(5):
+        win.append(ContextEntry(role="user", text=f"msg{i}", tokens=10))
+    # All earlier messages should appear in the summary except the most recent two.
+    assert "msg0" in win.summary
+    assert "msg1" in win.summary
+    assert "msg2" in win.summary
+    texts = [e.text for e in win.entries]
+    assert "msg3" in texts or "msg4" in texts
+
+
+# ---------------------------------------------------------------------------
+# render() returns summary + window in canonical order
+# ---------------------------------------------------------------------------
+
+
+def test_render_concatenates_summary_then_entries():
+    win = ContextWindow(
+        max_tokens=20,
+        summarizer=lambda dropped, current: " ".join(e.text for e in dropped),
+    )
+    win.append(ContextEntry(role="user", text="alpha", tokens=10))
+    win.append(ContextEntry(role="user", text="beta", tokens=10))
+    win.append(ContextEntry(role="user", text="gamma", tokens=10))
+    rendered = win.render()
+    # Summary appears first, then live entries in order.
+    assert rendered.index("alpha") < rendered.index("beta") < rendered.index("gamma")
+
+
+def test_render_omits_summary_block_when_summary_empty():
+    win = ContextWindow(max_tokens=100, summarizer=None)
+    win.append(ContextEntry(role="user", text="hi", tokens=2))
+    rendered = win.render()
+    assert rendered.strip().startswith("user:") or "hi" in rendered
+
+
+# ---------------------------------------------------------------------------
+# fits / would_fit predicates
+# ---------------------------------------------------------------------------
+
+
+def test_would_fit_true_when_entry_within_remaining():
+    win = ContextWindow(max_tokens=20, summarizer=None)
+    win.append(ContextEntry(role="user", text="x", tokens=10))
+    assert win.would_fit(tokens=5) is True
+
+
+def test_would_fit_false_when_entry_exceeds_remaining():
+    win = ContextWindow(max_tokens=20, summarizer=None)
+    win.append(ContextEntry(role="user", text="x", tokens=15))
+    assert win.would_fit(tokens=10) is False
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_oversized_single_entry_replaces_window_and_summary():
+    """An entry whose token count alone exceeds max_tokens still gets stored
+    (the alternative is silently dropping data); window may exceed budget
+    transiently. Caller's choice not to allow this is enforced via
+    would_fit beforehand."""
+    win = ContextWindow(max_tokens=10, summarizer=None)
+    win.append(ContextEntry(role="user", text="huge", tokens=50))
+    # Single entry survives — we don't pre-emptively drop a too-big entry.
+    assert win.entries[0].text == "huge"


### PR DESCRIPTION
## Summary

A token-budgeted conversational context primitive: wraps a list of role/text/token entries, and when an append would exceed the budget, pops the oldest entries off and (optionally) folds them into a persistent \`summary\` prefix via a caller-provided summarizer callback. The host-side primitive behind "Context persistence beyond token window" — each step the model sees \`summary || recent_entries\`, and the summary keeps growing as older context falls off.

Advances one goal-list item:
- **Context persistence beyond token window** (direct)

## API

\`\`\`python
from music_brain.generation import ContextEntry, ContextWindow

def my_summarizer(dropped, current_summary):
    # Caller's choice: extractive, abstractive, embedding-based, or identity.
    prev = current_summary + " | " if current_summary else ""
    return prev + " ".join(e.text for e in dropped)

win = ContextWindow(max_tokens=2048, summarizer=my_summarizer)
win.append(ContextEntry(role="user", text="Hello", tokens=10))
win.append(ContextEntry(role="assistant", text="Hi!", tokens=8))
# ... many more turns ...

if win.would_fit(tokens=500):
    win.append(big_assistant_turn)

prompt_text = win.render()  # "[summary] ... \\n user: ... \\n assistant: ..."
\`\`\`

Semantics:
- **Default eviction is FIFO.** Oldest entries pop first.
- **Summarizer is optional.** \`None\` → dropped entries are discarded.
- **Single oversized entries are kept** (alternative is silently dropping caller data). Use \`would_fit\` for strict-fit semantics.
- **Roles are validated** against \`{system, user, assistant, tool}\`.

## Tests

11 TDD-driven tests in \`tests/unit/test_context_window.py\` covering empty bootstrap, under-capacity append, invalid-role raise, overflow-without-summarizer drops oldest, overflow-with-summarizer compresses, summary persistence across multiple overflows, render order, \`would_fit\` predicate, and oversized-entry kept.

## Test plan

- [x] \`pytest tests/unit/test_context_window.py\` — 11/11
- [ ] CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new stateful context-management logic (eviction + optional summarization) that will shape what prompts are constructed, so subtle edge cases could affect downstream generation behavior once adopted.
> 
> **Overview**
> Adds a new `generation` context primitive, `ContextWindow`, which maintains a sliding token budget over `ContextEntry` turns, evicts oldest entries on overflow, and optionally calls a caller-provided summarizer to accumulate evicted content into a persistent `summary` prefix.
> 
> Exports the new API from `music_brain.generation`, provides a minimal `render()` for `summary || recent_entries`, validates roles/tokens, and includes unit tests covering overflow behavior (with/without summarizer), summary persistence, `would_fit`, rendering, and oversized-entry handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bec714ede5cef52f9616a7352c277387fe1157dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->