### PR TITLE
feat(audio): DualClip — aligned audio + MIDI representation

### DIFF
--- a/music_brain/audio/dual_clip.py
+++ b/music_brain/audio/dual_clip.py
@@ -1,0 +1,136 @@
+"""DualClip — audio buffer + aligned MIDI event list as one object.
+
+A small container for code that needs to keep audio and MIDI in sync —
+e.g. inference outputs (audio) joined with the symbolic events that
+generated them, or training pairs where each audio chunk has its
+corresponding MIDI annotation.
+
+Operations preserve alignment: :meth:`slice` extracts both a sample
+range and the events that fall inside it (rebased to start at 0);
+:meth:`concat` joins two clips and offsets the second clip's event
+times by the first clip's duration.
+
+Goal-list ties: Audio/MIDI dual representation (direct),
+Hybrid symbolic/audio generation (the host-side container for hybrid
+outputs).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterator, List
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class MidiEvent:
+    """Minimal MIDI note event keyed to wall time in seconds."""
+
+    time_sec: float
+    pitch: int
+    velocity: int
+    duration_sec: float
+
+    def __post_init__(self) -> None:
+        if self.time_sec < 0:
+            raise ValueError(f"time_sec must be >= 0; got {self.time_sec}")
+        if self.duration_sec < 0:
+            raise ValueError(f"duration_sec must be >= 0; got {self.duration_sec}")
+        if not 0 <= self.pitch <= 127:
+            raise ValueError(f"pitch must be in [0, 127]; got {self.pitch}")
+        if not 0 <= self.velocity <= 127:
+            raise ValueError(f"velocity must be in [0, 127]; got {self.velocity}")
+
+
+class DualClip:
+    """Aligned audio buffer + MIDI event list.
+
+    Events whose ``time_sec`` lies outside ``[0, duration_sec)`` are
+    rejected at construction.
+    """
+
+    def __init__(
+        self,
+        audio: np.ndarray,
+        sample_rate: int,
+        events: List[MidiEvent],
+    ) -> None:
+        if sample_rate <= 0:
+            raise ValueError("sample_rate must be > 0")
+        self.audio: np.ndarray = np.asarray(audio, dtype=np.float32)
+        self.sample_rate: int = int(sample_rate)
+        duration = self.duration_sec
+        for ev in events:
+            if not 0 <= ev.time_sec < max(duration, 1e-9):
+                raise ValueError(
+                    f"event time_sec={ev.time_sec} outside clip duration {duration}"
+                )
+        self.events: List[MidiEvent] = list(events)
+
+    # ----------------------------------------------------------------- meta
+    @property
+    def duration_sec(self) -> float:
+        return self.audio.shape[0] / self.sample_rate
+
+    def event_to_sample_index(self, event: MidiEvent) -> int:
+        return int(round(event.time_sec * self.sample_rate))
+
+    def sample_index_to_sec(self, sample_index: int) -> float:
+        return sample_index / self.sample_rate
+
+    # ----------------------------------------------------------------- ops
+    def slice(self, start_sec: float, end_sec: float) -> "DualClip":
+        """Return a new DualClip covering ``[start_sec, end_sec)``.
+
+        Bounds are clamped to the clip's own range. Events are filtered
+        and rebased so the returned clip's event times start at 0.
+        """
+        duration = self.duration_sec
+        start_sec = max(0.0, min(duration, start_sec))
+        end_sec = max(start_sec, min(duration, end_sec))
+        start_idx = int(round(start_sec * self.sample_rate))
+        end_idx = int(round(end_sec * self.sample_rate))
+        audio = self.audio[start_idx:end_idx].copy()
+        rebased: List[MidiEvent] = []
+        for ev in self.events:
+            if start_sec <= ev.time_sec < end_sec:
+                rebased.append(
+                    MidiEvent(
+                        time_sec=ev.time_sec - start_sec,
+                        pitch=ev.pitch,
+                        velocity=ev.velocity,
+                        duration_sec=ev.duration_sec,
+                    )
+                )
+        return DualClip(audio=audio, sample_rate=self.sample_rate, events=rebased)
+
+    def concat(self, other: "DualClip") -> "DualClip":
+        """Concatenate two clips. ``other``'s events are offset by self's duration."""
+        if self.sample_rate != other.sample_rate:
+            raise ValueError(
+                f"sample_rate mismatch: {self.sample_rate} vs {other.sample_rate}"
+            )
+        offset = self.duration_sec
+        offset_events = [
+            MidiEvent(
+                time_sec=ev.time_sec + offset,
+                pitch=ev.pitch,
+                velocity=ev.velocity,
+                duration_sec=ev.duration_sec,
+            )
+            for ev in other.events
+        ]
+        return DualClip(
+            audio=np.concatenate([self.audio, other.audio]),
+            sample_rate=self.sample_rate,
+            events=self.events + offset_events,
+        )
+
+    def iter_events_in_range(
+        self, start_sec: float, end_sec: float
+    ) -> Iterator[MidiEvent]:
+        """Yield events whose ``time_sec`` lies in ``[start_sec, end_sec)``."""
+        for ev in self.events:
+            if start_sec <= ev.time_sec < end_sec:
+                yield ev

--- a/tests/unit/test_dual_clip.py
+++ b/tests/unit/test_dual_clip.py
@@ -1,0 +1,154 @@
+"""DualClip — aligned audio + MIDI representation.
+
+Goal: Audio/MIDI dual representation (direct),
+Hybrid symbolic/audio generation (partial)."""
+
+import numpy as np
+import pytest
+
+from music_brain.audio.dual_clip import DualClip, MidiEvent
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+def test_clip_records_audio_and_events():
+    audio = np.arange(44100, dtype=np.float32)
+    events = [MidiEvent(time_sec=0.5, pitch=60, velocity=100, duration_sec=0.25)]
+    clip = DualClip(audio=audio, sample_rate=44100, events=events)
+    assert clip.duration_sec == pytest.approx(1.0)
+    assert len(clip.events) == 1
+
+
+def test_event_out_of_audio_range_raises():
+    audio = np.zeros(44100, dtype=np.float32)
+    bad_event = MidiEvent(time_sec=5.0, pitch=60, velocity=100, duration_sec=0.1)
+    with pytest.raises(ValueError, match="time_sec"):
+        DualClip(audio=audio, sample_rate=44100, events=[bad_event])
+
+
+def test_negative_time_event_raises():
+    audio = np.zeros(44100, dtype=np.float32)
+    with pytest.raises(ValueError, match="time_sec"):
+        DualClip(
+            audio=audio,
+            sample_rate=44100,
+            events=[MidiEvent(time_sec=-0.1, pitch=60, velocity=100, duration_sec=0.1)],
+        )
+
+
+# ---------------------------------------------------------------------------
+# slice
+# ---------------------------------------------------------------------------
+
+
+def test_slice_returns_aligned_audio_and_filtered_events():
+    audio = np.arange(44100, dtype=np.float32)
+    events = [
+        MidiEvent(time_sec=0.1, pitch=60, velocity=100, duration_sec=0.05),
+        MidiEvent(time_sec=0.5, pitch=64, velocity=90, duration_sec=0.05),
+        MidiEvent(time_sec=0.9, pitch=67, velocity=80, duration_sec=0.05),
+    ]
+    clip = DualClip(audio=audio, sample_rate=44100, events=events)
+    sliced = clip.slice(start_sec=0.4, end_sec=0.8)
+    # Audio sample count: 0.4s @ 44100 = 17640 samples
+    assert sliced.audio.shape == (17640,)
+    # First sample of slice equals original audio[start_sample]
+    assert sliced.audio[0] == pytest.approx(0.4 * 44100, abs=1.0)
+    # Only the middle event survives, rebased so time_sec=0 is the slice start.
+    assert len(sliced.events) == 1
+    assert sliced.events[0].pitch == 64
+    assert sliced.events[0].time_sec == pytest.approx(0.1, abs=1e-6)  # 0.5 - 0.4
+
+
+def test_slice_with_zero_length_returns_empty_clip():
+    audio = np.ones(44100, dtype=np.float32)
+    clip = DualClip(audio=audio, sample_rate=44100, events=[])
+    sliced = clip.slice(start_sec=0.3, end_sec=0.3)
+    assert sliced.audio.shape == (0,)
+    assert sliced.events == []
+
+
+def test_slice_clamps_to_clip_bounds():
+    audio = np.ones(44100, dtype=np.float32)
+    clip = DualClip(audio=audio, sample_rate=44100, events=[])
+    sliced = clip.slice(start_sec=-0.5, end_sec=2.0)
+    # Clamped to [0, 1]; same length as original.
+    assert sliced.audio.shape == (44100,)
+
+
+# ---------------------------------------------------------------------------
+# concat
+# ---------------------------------------------------------------------------
+
+
+def test_concat_joins_audio_and_offsets_event_times():
+    audio_a = np.ones(22050, dtype=np.float32)  # 0.5 s
+    audio_b = np.ones(22050, dtype=np.float32) * 2.0
+    events_a = [MidiEvent(time_sec=0.1, pitch=60, velocity=100, duration_sec=0.05)]
+    events_b = [MidiEvent(time_sec=0.2, pitch=64, velocity=90, duration_sec=0.05)]
+    a = DualClip(audio=audio_a, sample_rate=44100, events=events_a)
+    b = DualClip(audio=audio_b, sample_rate=44100, events=events_b)
+    joined = a.concat(b)
+    # Audio length: 0.5 + 0.5 = 1.0s
+    assert joined.duration_sec == pytest.approx(1.0)
+    # Events: first one at 0.1, second one at 0.5 + 0.2 = 0.7
+    assert len(joined.events) == 2
+    assert joined.events[0].time_sec == pytest.approx(0.1)
+    assert joined.events[1].time_sec == pytest.approx(0.7)
+
+
+def test_concat_sample_rate_mismatch_raises():
+    a = DualClip(audio=np.zeros(100, dtype=np.float32), sample_rate=44100, events=[])
+    b = DualClip(audio=np.zeros(100, dtype=np.float32), sample_rate=48000, events=[])
+    with pytest.raises(ValueError, match="sample_rate"):
+        a.concat(b)
+
+
+# ---------------------------------------------------------------------------
+# iter_events_in_range
+# ---------------------------------------------------------------------------
+
+
+def test_iter_events_in_range_filters_by_time():
+    audio = np.zeros(44100, dtype=np.float32)
+    events = [
+        MidiEvent(time_sec=0.1, pitch=60, velocity=100, duration_sec=0.05),
+        MidiEvent(time_sec=0.5, pitch=64, velocity=90, duration_sec=0.05),
+        MidiEvent(time_sec=0.9, pitch=67, velocity=80, duration_sec=0.05),
+    ]
+    clip = DualClip(audio=audio, sample_rate=44100, events=events)
+    inside = list(clip.iter_events_in_range(start_sec=0.4, end_sec=0.8))
+    assert [e.pitch for e in inside] == [64]
+
+
+def test_iter_events_in_range_inclusive_start_exclusive_end():
+    audio = np.zeros(44100, dtype=np.float32)
+    events = [
+        MidiEvent(time_sec=0.0, pitch=60, velocity=100, duration_sec=0.05),
+        MidiEvent(time_sec=0.5, pitch=64, velocity=90, duration_sec=0.05),
+    ]
+    clip = DualClip(audio=audio, sample_rate=44100, events=events)
+    # Inclusive at start, exclusive at end (matches numpy / Python slice convention).
+    inside = list(clip.iter_events_in_range(start_sec=0.0, end_sec=0.5))
+    assert [e.pitch for e in inside] == [60]
+
+
+# ---------------------------------------------------------------------------
+# event_to_sample_index / sample_index_to_sec
+# ---------------------------------------------------------------------------
+
+
+def test_event_to_sample_index_uses_sample_rate():
+    audio = np.zeros(44100, dtype=np.float32)
+    clip = DualClip(audio=audio, sample_rate=44100, events=[])
+    event = MidiEvent(time_sec=0.5, pitch=60, velocity=100, duration_sec=0.05)
+    assert clip.event_to_sample_index(event) == 22050
+
+
+def test_sample_index_to_sec_is_inverse_of_event_to_sample_index():
+    audio = np.zeros(44100, dtype=np.float32)
+    clip = DualClip(audio=audio, sample_rate=44100, events=[])
+    assert clip.sample_index_to_sec(22050) == pytest.approx(0.5)


### PR DESCRIPTION
## Summary

A small container for code that needs to keep audio and MIDI in sync — inference outputs joined with the symbolic events that generated them, training pairs where each audio chunk has a MIDI annotation, etc. Operations preserve alignment: \`slice\` extracts both a sample range and the events that fall inside it (rebased to start at 0); \`concat\` joins two clips and offsets the second's event times by the first's duration.

Advances two goal-list items:
- **Audio/MIDI dual representation** (direct)
- **Hybrid symbolic/audio generation** (host-side container for hybrid outputs)

## API

\`\`\`python
from music_brain.audio.dual_clip import DualClip, MidiEvent
import numpy as np

clip = DualClip(
    audio=np.zeros(44100, dtype=np.float32),
    sample_rate=44100,
    events=[MidiEvent(time_sec=0.5, pitch=60, velocity=100, duration_sec=0.25)],
)

half = clip.slice(start_sec=0.4, end_sec=0.8)
# half.audio: 17640 samples; half.events: [MidiEvent(time_sec=0.1, pitch=60, ...)]

joined = clip.concat(other_clip)  # sample-rate-checked; events offset by clip.duration_sec
\`\`\`

Validation:
- Events outside \`[0, duration_sec)\` are rejected at construction.
- Negative time_sec, pitch/velocity outside [0, 127] rejected by \`MidiEvent\`.
- \`concat\` raises on sample-rate mismatch (no implicit resampling).

## Tests

12 TDD-driven tests in \`tests/unit/test_dual_clip.py\` covering construction validation, slice rebase + clamping, concat offset adjustment, sample-rate-mismatch raise, event range filtering (half-open convention), and sample/sec round-trip.

## Test plan

- [x] \`pytest tests/unit/test_dual_clip.py\` — 12/12
- [ ] CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new standalone audio/MIDI container and unit tests without changing existing audio processing paths. Risk is low and mostly limited to correctness of time/sample alignment and edge-case validation in the new API.
> 
> **Overview**
> Introduces `DualClip` (and `MidiEvent`) as a new aligned audio+MIDI container, including validation of event ranges/pitch/velocity and helpers to convert between seconds and sample indices.
> 
> Adds alignment-preserving operations: `slice()` clamps bounds, extracts the audio window, and rebases filtered events; `concat()` joins audio, offsets the second clip’s event times by the first clip’s duration, and rejects sample-rate mismatches. Comprehensive unit tests cover construction validation and the slice/concat/range-iteration behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6260324b1188e8d48cc41bc3f37e3a738852d654. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->