### PR TITLE
feat(latent): multimodal fusion primitives — concat / weighted / gated / normalized

### DIFF
--- a/music_brain/latent/__init__.py
+++ b/music_brain/latent/__init__.py
@@ -1,0 +1,15 @@
+"""Latent-space utilities: fusion, retrieval, projection."""
+
+from music_brain.latent.fusion import (
+    concat_fuse,
+    gated_fuse,
+    normalized_average,
+    weighted_sum,
+)
+
+__all__ = [
+    "concat_fuse",
+    "gated_fuse",
+    "normalized_average",
+    "weighted_sum",
+]

--- a/music_brain/latent/fusion.py
+++ b/music_brain/latent/fusion.py
@@ -1,0 +1,116 @@
+"""Multimodal latent fusion primitives.
+
+Four NumPy strategies for combining 2+ embedding vectors into one, each
+appropriate for a different shape of fusion problem:
+
+  - ``concat_fuse(*v)`` — preserves all information from every modality;
+    growth in dimension is the cost.
+  - ``weighted_sum(vs, weights)`` — linear blend with implicit weight
+    normalisation; same dimension as inputs.
+  - ``gated_fuse(a, b, gate)`` — linear interpolation \\alpha·a + (1-\\alpha)·b
+    where \\alpha can be scalar or per-element. The host-side primitive
+    for "Latent emotional steering": slide a global mood-mix knob, or
+    steer per-dimension.
+  - ``normalized_average(vs)`` — L2-normalised mean direction; the
+    standard "align modalities on the unit sphere" recipe.
+
+Stdlib + numpy.
+
+Goal-list ties: Multimodal fusion engine (direct), Latent emotional
+steering (gated_fuse), Multimodal latent alignment (normalized_average).
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import numpy as np
+
+_DEFAULT_EPS = 1e-12
+
+
+def concat_fuse(*vectors: np.ndarray) -> np.ndarray:
+    """Concatenate vectors along the last axis."""
+    if not vectors:
+        raise ValueError("concat_fuse requires at least one vector")
+    return np.concatenate([np.asarray(v, dtype=np.float32) for v in vectors]).astype(
+        np.float32
+    )
+
+
+def weighted_sum(
+    vectors: Sequence[np.ndarray], weights: Sequence[float]
+) -> np.ndarray:
+    """Weighted linear blend. Weights are normalised to sum to 1.
+
+    Raises if ``vectors`` and ``weights`` differ in length, if any vector
+    has a different shape, or if all weights sum to zero.
+    """
+    if len(vectors) != len(weights):
+        raise ValueError(
+            f"length mismatch: {len(vectors)} vectors vs {len(weights)} weights"
+        )
+    if not vectors:
+        raise ValueError("weighted_sum requires at least one vector")
+    arrs = [np.asarray(v, dtype=np.float32) for v in vectors]
+    shape = arrs[0].shape
+    for a in arrs[1:]:
+        if a.shape != shape:
+            raise ValueError(f"shape mismatch: {a.shape} vs {shape}")
+    w = np.asarray(weights, dtype=np.float64)
+    total = w.sum()
+    if total <= 0:
+        raise ValueError("weights sum to zero — cannot normalise")
+    w = w / total
+    out = np.zeros(shape, dtype=np.float32)
+    for arr, scalar in zip(arrs, w):
+        out += (arr * scalar).astype(np.float32)
+    return out
+
+
+def gated_fuse(
+    a: np.ndarray,
+    b: np.ndarray,
+    gate: Union[float, np.ndarray],
+) -> np.ndarray:
+    """Linear interpolation ``gate * a + (1 - gate) * b``.
+
+    ``gate`` may be a scalar (global) or a vector of the same shape as
+    ``a`` and ``b`` (per-element steering). Values must lie in ``[0, 1]``.
+    """
+    a = np.asarray(a, dtype=np.float32)
+    b = np.asarray(b, dtype=np.float32)
+    if a.shape != b.shape:
+        raise ValueError(f"shape mismatch: {a.shape} vs {b.shape}")
+    if isinstance(gate, np.ndarray):
+        g = gate.astype(np.float32)
+        if g.shape != a.shape:
+            raise ValueError(f"gate shape mismatch: {g.shape} vs {a.shape}")
+        if np.any(g < 0) or np.any(g > 1):
+            raise ValueError("gate vector entries must lie in [0, 1]")
+    else:
+        if not 0.0 <= gate <= 1.0:
+            raise ValueError(f"gate must lie in [0, 1]; got {gate}")
+        g = np.float32(gate)
+    return (g * a + (1.0 - g) * b).astype(np.float32)
+
+
+def normalized_average(vectors: Sequence[np.ndarray]) -> np.ndarray:
+    """Mean of the inputs, then L2-normalised.
+
+    Zero-mean output (vectors cancel out) is returned as zero instead of
+    NaN. The recipe of "average then re-normalise to the unit sphere" is
+    the standard alignment step for late multimodal fusion.
+    """
+    if not vectors:
+        raise ValueError("normalized_average requires at least one vector")
+    arrs = [np.asarray(v, dtype=np.float32) for v in vectors]
+    shape = arrs[0].shape
+    for a in arrs[1:]:
+        if a.shape != shape:
+            raise ValueError(f"shape mismatch: {a.shape} vs {shape}")
+    mean = np.mean(arrs, axis=0).astype(np.float32)
+    norm = float(np.linalg.norm(mean))
+    if norm <= _DEFAULT_EPS:
+        return np.zeros_like(mean)
+    return (mean / norm).astype(np.float32)

--- a/tests/unit/test_fusion.py
+++ b/tests/unit/test_fusion.py
@@ -1,0 +1,137 @@
+"""Multimodal fusion primitives (Goal: Multimodal fusion engine,
+Latent emotional steering via gated fusion, Multimodal latent alignment)."""
+
+import numpy as np
+import pytest
+
+from music_brain.latent.fusion import (
+    concat_fuse,
+    gated_fuse,
+    normalized_average,
+    weighted_sum,
+)
+
+
+# ---------------------------------------------------------------------------
+# concat_fuse
+# ---------------------------------------------------------------------------
+
+
+def test_concat_fuse_joins_along_last_axis():
+    a = np.array([1.0, 2.0], dtype=np.float32)
+    b = np.array([3.0, 4.0, 5.0], dtype=np.float32)
+    out = concat_fuse(a, b)
+    assert out.tolist() == [1.0, 2.0, 3.0, 4.0, 5.0]
+
+
+def test_concat_fuse_handles_three_or_more_inputs():
+    out = concat_fuse(
+        np.array([1.0], dtype=np.float32),
+        np.array([2.0, 3.0], dtype=np.float32),
+        np.array([4.0], dtype=np.float32),
+    )
+    assert out.tolist() == [1.0, 2.0, 3.0, 4.0]
+
+
+def test_concat_fuse_at_least_one_arg():
+    with pytest.raises(ValueError, match="at least one"):
+        concat_fuse()
+
+
+# ---------------------------------------------------------------------------
+# weighted_sum
+# ---------------------------------------------------------------------------
+
+
+def test_weighted_sum_with_equal_weights():
+    a = np.array([1.0, 2.0], dtype=np.float32)
+    b = np.array([3.0, 4.0], dtype=np.float32)
+    out = weighted_sum([a, b], weights=[0.5, 0.5])
+    assert out.tolist() == [2.0, 3.0]
+
+
+def test_weighted_sum_normalises_weights_implicitly():
+    """Caller may pass un-normalised weights — function normalises."""
+    a = np.array([1.0, 0.0], dtype=np.float32)
+    b = np.array([0.0, 1.0], dtype=np.float32)
+    out = weighted_sum([a, b], weights=[3.0, 1.0])  # 3:1 ratio
+    assert out[0] == pytest.approx(0.75)
+    assert out[1] == pytest.approx(0.25)
+
+
+def test_weighted_sum_shape_mismatch_raises():
+    a = np.array([1.0, 2.0], dtype=np.float32)
+    b = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+    with pytest.raises(ValueError, match="shape"):
+        weighted_sum([a, b], weights=[0.5, 0.5])
+
+
+def test_weighted_sum_length_mismatch_raises():
+    a = np.array([1.0], dtype=np.float32)
+    with pytest.raises(ValueError, match="length"):
+        weighted_sum([a, a], weights=[0.5])
+
+
+def test_weighted_sum_zero_weights_raises():
+    a = np.array([1.0], dtype=np.float32)
+    with pytest.raises(ValueError, match="weights"):
+        weighted_sum([a, a], weights=[0.0, 0.0])
+
+
+# ---------------------------------------------------------------------------
+# gated_fuse
+# ---------------------------------------------------------------------------
+
+
+def test_gated_fuse_scalar_gate_linear_interpolation():
+    """gate=0.7 → 0.7*a + 0.3*b."""
+    a = np.array([1.0, 1.0], dtype=np.float32)
+    b = np.array([0.0, 0.0], dtype=np.float32)
+    out = gated_fuse(a, b, gate=0.7)
+    assert out == pytest.approx([0.7, 0.7])
+
+
+def test_gated_fuse_vector_gate_elementwise():
+    a = np.array([1.0, 1.0, 1.0], dtype=np.float32)
+    b = np.array([0.0, 0.0, 0.0], dtype=np.float32)
+    gate = np.array([0.0, 0.5, 1.0], dtype=np.float32)
+    out = gated_fuse(a, b, gate=gate)
+    assert out == pytest.approx([0.0, 0.5, 1.0])
+
+
+def test_gated_fuse_gate_outside_unit_range_raises():
+    a = np.zeros(2, dtype=np.float32)
+    b = np.zeros(2, dtype=np.float32)
+    with pytest.raises(ValueError, match="gate"):
+        gated_fuse(a, b, gate=1.5)
+    with pytest.raises(ValueError, match="gate"):
+        gated_fuse(a, b, gate=np.array([0.5, 1.7], dtype=np.float32))
+
+
+# ---------------------------------------------------------------------------
+# normalized_average
+# ---------------------------------------------------------------------------
+
+
+def test_normalized_average_yields_unit_length_output():
+    a = np.array([3.0, 0.0], dtype=np.float32)  # length 3
+    b = np.array([0.0, 4.0], dtype=np.float32)  # length 4
+    out = normalized_average([a, b])
+    assert np.linalg.norm(out) == pytest.approx(1.0)
+
+
+def test_normalized_average_preserves_direction_of_aligned_inputs():
+    """When all inputs already point the same way, normalized average == l2_norm of one."""
+    a = np.array([3.0, 0.0], dtype=np.float32)
+    out = normalized_average([a, a, a])
+    assert out == pytest.approx([1.0, 0.0])
+
+
+def test_normalized_average_zero_input_returns_zero():
+    out = normalized_average([np.zeros(3, dtype=np.float32)])
+    assert np.all(out == 0.0)
+
+
+def test_normalized_average_zero_inputs_raises():
+    with pytest.raises(ValueError, match="at least one"):
+        normalized_average([])


### PR DESCRIPTION
## Summary

Four NumPy strategies for combining 2+ embedding vectors into one, each appropriate for a different shape of fusion problem. Library-agnostic, no model dependency.

Advances three goal-list items:
- **Multimodal fusion engine** (direct)
- **Latent emotional steering** (\`gated_fuse\` is the host-side primitive)
- **Multimodal latent alignment** (\`normalized_average\`)

## API

\`\`\`python
from music_brain.latent.fusion import concat_fuse, weighted_sum, gated_fuse, normalized_average
\`\`\`

| Function | Use when |
|---|---|
| \`concat_fuse(*v)\` | preserve every modality's info; OK with dim growth |
| \`weighted_sum(vs, weights)\` | linear blend; weights implicitly normalised |
| \`gated_fuse(a, b, gate)\` | linear interp \`α·a + (1-α)·b\`; scalar gate (global) or per-element vector — the emotional-steering primitive |
| \`normalized_average(vs)\` | mean → L2-normalise; the standard align-on-unit-sphere recipe; zero-mean returns zero (no NaN) |

All four enforce shape consistency across inputs and raise on degenerate configurations (zero-summing weights, gate outside \`[0, 1]\`, shape mismatch).

## Tests

15 TDD-driven tests in \`tests/unit/test_fusion.py\` covering: concat join + 3+ inputs, weighted-sum normalisation + length/shape/zero-weight errors, gated scalar interp, gated vector elementwise, gate out-of-range raise, normalized-average unit-length output, direction preservation when aligned, zero-input zero output, empty-input raise.

## Test plan

- [x] \`pytest tests/unit/test_fusion.py\` — 15/15
- [ ] CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new NumPy-only helper functions and unit tests without touching existing runtime paths; main risk is API/behavior expectations around input validation and numeric edge cases (e.g., zero-sum weights, zero-norm mean).
> 
> **Overview**
> Adds a new `music_brain.latent` package exposing four NumPy-based embedding fusion primitives: `concat_fuse`, `weighted_sum` (auto-normalizes weights), `gated_fuse` (scalar or per-element gate in `[0,1]`), and `normalized_average` (mean then L2-normalize, returning zeros on near-zero norm).
> 
> Includes comprehensive unit coverage for happy paths and validation/error cases (shape/length mismatches, invalid gates, zero-sum weights, and empty inputs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f07985aeb25993e70e8c5898392c97fb9ac54804. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->