### PR TITLE
feat(symbolic): chord-to-MIDI realizer — parse / notes / realize_progression

### DIFF
--- a/music_brain/symbolic/__init__.py
+++ b/music_brain/symbolic/__init__.py
@@ -1,0 +1,17 @@
+"""Symbolic music utilities: chord parsing, progression realization."""
+
+from music_brain.symbolic.realize import (
+    Chord,
+    NoteEvent,
+    chord_notes,
+    parse_chord,
+    realize_progression,
+)
+
+__all__ = [
+    "Chord",
+    "NoteEvent",
+    "chord_notes",
+    "parse_chord",
+    "realize_progression",
+]

--- a/music_brain/symbolic/realize.py
+++ b/music_brain/symbolic/realize.py
@@ -1,0 +1,160 @@
+"""Symbolic chord-to-MIDI realizer.
+
+A small, library-agnostic chord parser plus a progression-to-MIDI-events
+realizer. Covers the common chord qualities a generation pipeline needs
+to land notes on the wire: major / minor triads, dom7 / minor7 / maj7
+sevenths. Stdlib only — no music21, no mido.
+
+Inputs are textual chord symbols (``"C"``, ``"Am"``, ``"G7"``, ``"Bb"``,
+``"F#m"``, ``"Cmaj7"``). Output for the progression realizer is a list
+of :class:`NoteEvent` ``(time_sec, pitch, velocity, duration_sec)`` —
+the same shape as :class:`music_brain.audio.dual_clip.MidiEvent`, so
+the two compose naturally for hybrid symbolic+audio outputs.
+
+Goal-list ties:
+  - Symbolic realization layer (direct)
+  - Harmonic progression planning (the realization step beneath the
+    planner)
+  - Hybrid symbolic/audio generation (host-side note emitter)
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import List, Sequence, Tuple
+
+# Pitch-class lookup for chord roots.
+_ROOT_PITCH_CLASS = {
+    "C": 0,
+    "C#": 1,
+    "Db": 1,
+    "D": 2,
+    "D#": 3,
+    "Eb": 3,
+    "E": 4,
+    "F": 5,
+    "F#": 6,
+    "Gb": 6,
+    "G": 7,
+    "G#": 8,
+    "Ab": 8,
+    "A": 9,
+    "A#": 10,
+    "Bb": 10,
+    "B": 11,
+}
+
+# Interval patterns relative to root.
+_QUALITY_INTERVALS = {
+    "major": (0, 4, 7),
+    "minor": (0, 3, 7),
+    "dom7": (0, 4, 7, 10),
+    "minor7": (0, 3, 7, 10),
+    "maj7": (0, 4, 7, 11),
+}
+
+# Order matters: longest suffix first so "maj7" wins over "m7" → "minor7".
+_QUALITY_SUFFIXES: Tuple[Tuple[str, str], ...] = (
+    ("maj7", "maj7"),
+    ("m7", "minor7"),
+    ("7", "dom7"),
+    ("m", "minor"),
+    ("", "major"),
+)
+
+_ROOT_RE = re.compile(r"^([A-G][#b]?)(.*)$")
+
+
+@dataclass(frozen=True)
+class Chord:
+    """Parsed chord representation."""
+
+    root_pc: int  # 0-11 (C = 0)
+    quality: str
+    intervals: Tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class NoteEvent:
+    """One sounded note. Same shape as ``MidiEvent`` in audio.dual_clip."""
+
+    time_sec: float
+    pitch: int
+    velocity: int
+    duration_sec: float
+
+
+def parse_chord(symbol: str) -> Chord:
+    """Parse a chord symbol like ``"Am7"`` into a :class:`Chord`.
+
+    Raises :class:`ValueError` on empty input or unrecognised root.
+    """
+    if not symbol:
+        raise ValueError("cannot parse empty chord symbol")
+    m = _ROOT_RE.match(symbol)
+    if not m:
+        raise ValueError(f"unrecognised root in chord symbol: {symbol!r}")
+    root_str, suffix = m.group(1), m.group(2)
+    if root_str not in _ROOT_PITCH_CLASS:
+        raise ValueError(f"unrecognised root note: {root_str!r}")
+    root_pc = _ROOT_PITCH_CLASS[root_str]
+    quality = "major"
+    for suf, qual in _QUALITY_SUFFIXES:
+        if suffix == suf:
+            quality = qual
+            break
+    else:
+        # `else` on for-else only runs if no break — quality stays 'major'.
+        pass
+    return Chord(
+        root_pc=root_pc,
+        quality=quality,
+        intervals=_QUALITY_INTERVALS[quality],
+    )
+
+
+def chord_notes(symbol: str, octave: int = 4) -> List[int]:
+    """Return MIDI pitch numbers for the chord at the given octave.
+
+    The root is placed at ``octave`` (e.g. ``octave=4`` → C4 = MIDI 60).
+    Higher chord tones may wrap into the next octave.
+    """
+    chord = parse_chord(symbol)
+    root_midi = 12 * (octave + 1) + chord.root_pc
+    return [root_midi + iv for iv in chord.intervals]
+
+
+def realize_progression(
+    progression: Sequence[dict],
+    bpm: float,
+    velocity: int,
+    octave: int = 4,
+) -> List[NoteEvent]:
+    """Realize a chord progression as a list of :class:`NoteEvent`.
+
+    Each entry of ``progression`` must be a dict with keys ``"chord"``
+    (chord symbol) and ``"duration_beats"`` (length of the chord in
+    beats). ``bpm`` converts beats to seconds; ``velocity`` is applied
+    uniformly to every emitted note.
+    """
+    if bpm <= 0:
+        raise ValueError("bpm must be > 0")
+    sec_per_beat = 60.0 / bpm
+    out: List[NoteEvent] = []
+    cursor_sec = 0.0
+    for entry in progression:
+        symbol = entry["chord"]
+        duration_beats = float(entry["duration_beats"])
+        duration_sec = duration_beats * sec_per_beat
+        for pitch in chord_notes(symbol, octave=octave):
+            out.append(
+                NoteEvent(
+                    time_sec=cursor_sec,
+                    pitch=pitch,
+                    velocity=velocity,
+                    duration_sec=duration_sec,
+                )
+            )
+        cursor_sec += duration_sec
+    return out

--- a/tests/unit/test_symbolic_realize.py
+++ b/tests/unit/test_symbolic_realize.py
@@ -1,0 +1,142 @@
+"""Chord-to-MIDI realizer (Goal: Symbolic realization layer,
+Harmonic progression planning, Hybrid symbolic/audio generation)."""
+
+import pytest
+
+from music_brain.symbolic.realize import (
+    chord_notes,
+    parse_chord,
+    realize_progression,
+)
+
+
+# ---------------------------------------------------------------------------
+# parse_chord
+# ---------------------------------------------------------------------------
+
+
+def test_parse_major_triad():
+    chord = parse_chord("C")
+    assert chord.root_pc == 0  # C
+    assert chord.quality == "major"
+    assert chord.intervals == (0, 4, 7)
+
+
+def test_parse_minor_triad():
+    chord = parse_chord("Am")
+    assert chord.root_pc == 9  # A
+    assert chord.quality == "minor"
+    assert chord.intervals == (0, 3, 7)
+
+
+def test_parse_seventh_chord():
+    chord = parse_chord("G7")
+    assert chord.root_pc == 7  # G
+    assert chord.quality == "dom7"
+    # Dominant 7th: root, M3, P5, m7
+    assert chord.intervals == (0, 4, 7, 10)
+
+
+def test_parse_minor_seventh():
+    chord = parse_chord("Dm7")
+    assert chord.root_pc == 2  # D
+    assert chord.quality == "minor7"
+    assert chord.intervals == (0, 3, 7, 10)
+
+
+def test_parse_major_seventh():
+    chord = parse_chord("Cmaj7")
+    assert chord.root_pc == 0
+    assert chord.quality == "maj7"
+    assert chord.intervals == (0, 4, 7, 11)
+
+
+def test_parse_sharp_root():
+    chord = parse_chord("F#m")
+    assert chord.root_pc == 6  # F#
+    assert chord.quality == "minor"
+
+
+def test_parse_flat_root():
+    chord = parse_chord("Bb")
+    assert chord.root_pc == 10  # Bb
+    assert chord.quality == "major"
+
+
+def test_parse_invalid_root_raises():
+    with pytest.raises(ValueError, match="root"):
+        parse_chord("H7")
+
+
+def test_parse_empty_raises():
+    with pytest.raises(ValueError, match="empty"):
+        parse_chord("")
+
+
+# ---------------------------------------------------------------------------
+# chord_notes (MIDI pitch numbers)
+# ---------------------------------------------------------------------------
+
+
+def test_chord_notes_default_octave_is_4():
+    """C major triad in octave 4 → MIDI 60 (C4), 64 (E4), 67 (G4)."""
+    notes = chord_notes("C")
+    assert notes == [60, 64, 67]
+
+
+def test_chord_notes_custom_octave():
+    """Am in octave 3 → A3 (57), C4 (60), E4 (64)."""
+    notes = chord_notes("Am", octave=3)
+    assert notes == [57, 60, 64]
+
+
+def test_chord_notes_seventh_chord_has_four_notes():
+    notes = chord_notes("G7", octave=4)
+    # G4=67, B4=71, D5=74, F5=77
+    assert notes == [67, 71, 74, 77]
+
+
+# ---------------------------------------------------------------------------
+# realize_progression
+# ---------------------------------------------------------------------------
+
+
+def test_realize_progression_outputs_one_event_per_chord_note():
+    progression = [
+        {"chord": "C", "duration_beats": 4},
+        {"chord": "Am", "duration_beats": 4},
+    ]
+    events = realize_progression(progression, bpm=120, velocity=80)
+    # 2 chords × 3 notes each = 6 events.
+    assert len(events) == 6
+    # All same velocity.
+    assert all(e.velocity == 80 for e in events)
+
+
+def test_realize_progression_event_times_advance_with_duration():
+    progression = [
+        {"chord": "C", "duration_beats": 2},
+        {"chord": "F", "duration_beats": 2},
+    ]
+    events = realize_progression(progression, bpm=120, velocity=80)
+    # 2 beats at 120bpm = 1.0 second.
+    first_chord = [e for e in events if e.time_sec == pytest.approx(0.0)]
+    second_chord = [e for e in events if e.time_sec == pytest.approx(1.0)]
+    assert len(first_chord) == 3
+    assert len(second_chord) == 3
+
+
+def test_realize_progression_duration_matches_chord_length():
+    progression = [{"chord": "C", "duration_beats": 4}]
+    events = realize_progression(progression, bpm=120, velocity=80)
+    # 4 beats at 120bpm = 2.0 seconds per note.
+    assert all(e.duration_sec == pytest.approx(2.0) for e in events)
+
+
+def test_realize_progression_empty_returns_empty():
+    assert realize_progression([], bpm=120, velocity=80) == []
+
+
+def test_realize_progression_invalid_bpm_raises():
+    with pytest.raises(ValueError, match="bpm"):
+        realize_progression([{"chord": "C", "duration_beats": 4}], bpm=0, velocity=80)


### PR DESCRIPTION
## Summary

A small, library-agnostic chord parser plus a progression-to-MIDI-events realizer. Covers the chord qualities a generation pipeline actually needs to land notes on the wire: major / minor triads, dom7 / minor7 / maj7 sevenths. Stdlib only — no music21, no mido.

\`NoteEvent\` shape matches \`MidiEvent\` in \`audio.dual_clip\`, so symbolic and audio paths compose naturally for hybrid outputs.

Advances three goal-list items:
- **Symbolic realization layer** (direct)
- **Harmonic progression planning** (the realization step beneath the planner)
- **Hybrid symbolic/audio generation** (host-side note emitter)

## API

\`\`\`python
from music_brain.symbolic import parse_chord, chord_notes, realize_progression

parse_chord("Am7")                 # Chord(root_pc=9, quality="minor7", intervals=(0,3,7,10))
chord_notes("G7", octave=4)        # [67, 71, 74, 77]  (G4, B4, D5, F5)

realize_progression(
    [{"chord": "C", "duration_beats": 4}, {"chord": "Am", "duration_beats": 4}],
    bpm=120,
    velocity=80,
)
# → [NoteEvent(time_sec=0.0, pitch=60, velocity=80, duration_sec=2.0), ...]
\`\`\`

Recognised qualities: \`major\`, \`minor\`, \`dom7\`, \`minor7\`, \`maj7\`. Suffix parsing prioritises longest match (so \`maj7\` wins over \`m7\` → \`minor7\`). Sharps and flats both supported (\`C#\` and \`Db\` both map to PC 1).

## Tests

17 TDD-driven tests in \`tests/unit/test_symbolic_realize.py\`:
- Parsing: major/minor triads, dom7/minor7/maj7 sevenths, sharps + flats, invalid root and empty input raise
- Note generation: default octave, custom octave, 4-note count for sevenths
- Progression realizer: event-count math, time advance per chord, duration_sec from bpm, empty progression, invalid bpm raise

## Test plan

- [x] \`pytest tests/unit/test_symbolic_realize.py\` — 17/17
- [ ] CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are purely additive (new module + exports + unit tests) with straightforward parsing/math and no impact on existing runtime paths unless explicitly imported.
> 
> **Overview**
> Introduces a new `music_brain.symbolic` package that can **parse common chord symbols** (major/minor triads and `7`/`m7`/`maj7` sevenths, including sharps/flats) and **convert them into MIDI pitch lists** via `chord_notes`.
> 
> Adds `realize_progression` to turn a chord+duration progression into a list of timed `NoteEvent`s (seconds derived from BPM, uniform velocity), and exposes the API via `music_brain.symbolic.__init__`.
> 
> Includes comprehensive unit tests covering chord parsing, MIDI note generation, progression timing/duration behavior, and input validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff61630cf77b1df91a6c719ed10965fd949d3895. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->