### PR TITLE
feat(session): WorldState — persistent session state with history

### DIFF
--- a/music_brain/session/world_state.py
+++ b/music_brain/session/world_state.py
@@ -1,0 +1,103 @@
+"""WorldState — persistent musical session state with history.
+
+A long-lived state object for a creative session: current key, tempo,
+section, emotion + an append-only history log of every transition. Used
+by orchestrators that need to know "what was just happening" to bias the
+next decision toward continuity, and by retrieval code that wants to
+key into the user's recent journey.
+
+History entries are stored as ``{"kind": ..., "from": ..., "to": ...}``
+dicts so they round-trip cleanly through JSON without custom decoders.
+
+Stdlib only.
+
+Goal-list ties:
+  - Persistent latent world-state modeling (direct)
+  - Longitudinal user modeling (state-tracking prerequisite)
+  - Arrangement continuity preservation (section history)
+  - Creative companion interaction model (session memory the companion
+    can refer back to)
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+
+@dataclass
+class WorldState:
+    """Persistent session state. Updates record to ``history``."""
+
+    key: str = ""
+    tempo: int = 0
+    current_section: Optional[str] = None
+    current_emotion: Optional[str] = None
+    history: List[Dict[str, Any]] = field(default_factory=list)
+
+    # ----------------------------------------------------------------- mutate
+    def update_section(self, section: Optional[str]) -> None:
+        """Set current section; appends to history unless unchanged."""
+        if section == self.current_section:
+            return
+        self.history.append(
+            {"kind": "section", "from": self.current_section, "to": section}
+        )
+        self.current_section = section
+
+    def update_emotion(self, emotion: Optional[str]) -> None:
+        """Set current emotion; appends to history unless unchanged."""
+        if emotion == self.current_emotion:
+            return
+        self.history.append(
+            {"kind": "emotion", "from": self.current_emotion, "to": emotion}
+        )
+        self.current_emotion = emotion
+
+    def reset_history(self) -> None:
+        """Clear the history log but keep the current state values."""
+        self.history.clear()
+
+    # ----------------------------------------------------------------- query
+    def section_transition_count(self) -> int:
+        return sum(1 for e in self.history if e["kind"] == "section")
+
+    def recent_sections(self, n: int) -> List[str]:
+        """Last ``n`` section ``to`` values in chronological order."""
+        sections = [e["to"] for e in self.history if e["kind"] == "section"]
+        return sections[-n:]
+
+    # --------------------------------------------------------- serialisation
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "key": self.key,
+                "tempo": self.tempo,
+                "current_section": self.current_section,
+                "current_emotion": self.current_emotion,
+                "history": self.history,
+            }
+        )
+
+    @classmethod
+    def from_json(cls, payload: str) -> "WorldState":
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"invalid JSON: {e}") from e
+        return cls(
+            key=data.get("key", ""),
+            tempo=int(data.get("tempo", 0)),
+            current_section=data.get("current_section"),
+            current_emotion=data.get("current_emotion"),
+            history=list(data.get("history", [])),
+        )
+
+    def save(self, path: Union[Path, str]) -> None:
+        Path(path).write_text(self.to_json(), encoding="utf-8")
+
+    @classmethod
+    def load(cls, path: Union[Path, str]) -> "WorldState":
+        return cls.from_json(Path(path).read_text(encoding="utf-8"))

--- a/tests/unit/test_world_state.py
+++ b/tests/unit/test_world_state.py
@@ -1,0 +1,139 @@
+"""WorldState — persistent musical session state with history (Goal:
+Persistent latent world-state modeling, Longitudinal user modeling,
+Arrangement continuity preservation)."""
+
+import pytest
+from pathlib import Path
+
+from music_brain.session.world_state import WorldState
+
+
+# ---------------------------------------------------------------------------
+# Construction & defaults
+# ---------------------------------------------------------------------------
+
+
+def test_world_state_starts_with_defaults():
+    state = WorldState()
+    assert state.key == ""
+    assert state.tempo == 0
+    assert state.current_section is None
+    assert state.current_emotion is None
+    assert state.history == []
+
+
+def test_world_state_accepts_initial_values():
+    state = WorldState(key="C major", tempo=120, current_section="intro")
+    assert state.key == "C major"
+    assert state.tempo == 120
+    assert state.current_section == "intro"
+
+
+# ---------------------------------------------------------------------------
+# update_section / update_emotion record history
+# ---------------------------------------------------------------------------
+
+
+def test_update_section_appends_to_history():
+    state = WorldState(current_section="intro")
+    state.update_section("verse")
+    assert state.current_section == "verse"
+    assert state.history[-1] == {"kind": "section", "from": "intro", "to": "verse"}
+
+
+def test_update_emotion_appends_to_history():
+    state = WorldState()
+    state.update_emotion("tension")
+    assert state.current_emotion == "tension"
+    assert state.history[-1] == {"kind": "emotion", "from": None, "to": "tension"}
+
+
+def test_no_op_updates_dont_add_history():
+    """Updating to the same value should not bloat the history log."""
+    state = WorldState(current_section="verse")
+    state.update_section("verse")
+    assert state.history == []
+
+
+def test_history_preserves_chronological_order():
+    state = WorldState()
+    state.update_section("intro")
+    state.update_emotion("hope")
+    state.update_section("chorus")
+    kinds = [entry["kind"] for entry in state.history]
+    assert kinds == ["section", "emotion", "section"]
+
+
+# ---------------------------------------------------------------------------
+# transition_count helpers
+# ---------------------------------------------------------------------------
+
+
+def test_section_transition_count_zero_initially():
+    state = WorldState()
+    assert state.section_transition_count() == 0
+
+
+def test_section_transition_count_increments_per_change():
+    state = WorldState()
+    state.update_section("intro")
+    state.update_section("verse")
+    state.update_section("chorus")
+    assert state.section_transition_count() == 3
+
+
+def test_recent_sections_returns_last_n_in_order():
+    state = WorldState()
+    for section in ["intro", "verse", "chorus", "verse", "outro"]:
+        state.update_section(section)
+    assert state.recent_sections(3) == ["chorus", "verse", "outro"]
+
+
+# ---------------------------------------------------------------------------
+# Serialisation round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_to_json_and_from_json_round_trip():
+    state = WorldState(key="D minor", tempo=100, current_section="bridge")
+    state.update_section("chorus")
+    state.update_emotion("release")
+    payload = state.to_json()
+    restored = WorldState.from_json(payload)
+    assert restored.key == "D minor"
+    assert restored.tempo == 100
+    assert restored.current_section == "chorus"
+    assert restored.current_emotion == "release"
+    assert restored.history == state.history
+
+
+def test_from_json_with_invalid_payload_raises():
+    with pytest.raises(ValueError):
+        WorldState.from_json("not-json")
+
+
+def test_save_load_round_trip(tmp_path: Path):
+    state = WorldState(key="A minor", tempo=140)
+    state.update_section("intro")
+    file_path = tmp_path / "ws.json"
+    state.save(file_path)
+    assert file_path.exists()
+    restored = WorldState.load(file_path)
+    assert restored.key == "A minor"
+    assert restored.tempo == 140
+    assert restored.current_section == "intro"
+
+
+# ---------------------------------------------------------------------------
+# clear / reset_history
+# ---------------------------------------------------------------------------
+
+
+def test_reset_history_keeps_current_state_but_drops_log():
+    state = WorldState(current_section="verse")
+    state.update_section("chorus")
+    state.update_emotion("longing")
+    state.reset_history()
+    assert state.current_section == "chorus"
+    assert state.current_emotion == "longing"
+    assert state.history == []


### PR DESCRIPTION
## Summary

A long-lived state object for a creative session: current key, tempo, section, emotion + an append-only history log of every transition. Used by orchestrators that need to know "what was just happening" to bias the next decision toward continuity, and by retrieval code that wants to key into the user's recent journey.

History entries round-trip cleanly through JSON (no custom decoders).

Advances four goal-list items:
- **Persistent latent world-state modeling** (direct)
- **Longitudinal user modeling** (the state-tracking prerequisite)
- **Arrangement continuity preservation** (section history)
- **Creative companion interaction model** (session memory the companion can refer back to)

## API

\`\`\`python
from music_brain.session.world_state import WorldState

ws = WorldState(key="C major", tempo=120)
ws.update_section("intro")
ws.update_emotion("hope")
ws.update_section("verse")          # appends {kind:section, from:intro, to:verse}
ws.update_section("verse")          # no-op: same value → no history entry

ws.section_transition_count()       # → 2
ws.recent_sections(3)               # → ["intro", "verse"]

ws.save("/tmp/session.json")
restored = WorldState.load("/tmp/session.json")
\`\`\`

No-op updates (same value as current) are dropped to keep the history log signal-dense rather than padding-dense.

## Tests

13 TDD-driven tests in \`tests/unit/test_world_state.py\` covering: defaults, initial values, update appends history, no-op updates skip history, chronological order, transition count, recent_sections, JSON round-trip, invalid JSON raise, save/load round-trip, reset_history keeps state.

## Test plan

- [x] \`pytest tests/unit/test_world_state.py\` — 13/13
- [ ] CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new session-state container with JSON/file persistence and helper queries; risk is low since it’s isolated and fully covered by unit tests, but future consumers must ensure history payloads remain JSON-safe.
> 
> **Overview**
> Introduces `WorldState`, a new persistent session-state object that tracks key/tempo plus current section/emotion and records every section/emotion change into an append-only `history` (skipping no-op updates).
> 
> Adds helpers to query continuity (`section_transition_count`, `recent_sections`) and supports JSON + file round-tripping via `to_json`/`from_json` and `save`/`load`, with new unit tests validating defaults, history semantics, ordering, serialization, and reset behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ca77316861e3bfb72ca14eb4cfea1a3dcc08df8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->