### PR TITLE
feat(latent): LinearProjection — affine bridge between embedding spaces

### DIFF
--- a/music_brain/latent/__init__.py
+++ b/music_brain/latent/__init__.py
@@ -1,0 +1,5 @@
+"""Latent-space utilities: projection bridges between embedding spaces."""
+
+from music_brain.latent.projection import LinearProjection
+
+__all__ = ["LinearProjection"]

--- a/music_brain/latent/projection.py
+++ b/music_brain/latent/projection.py
@@ -1,0 +1,119 @@
+"""LinearProjection — small affine bridge between embedding spaces.
+
+A weights+bias pair plus apply() / save / load. Used wherever the music
+brain stack needs to glue two embedding spaces of different dimensions —
+e.g. conditioning a 256-d intent representation into a 384-d audio
+encoder's input space, or attaching a low-rank adapter on top of a
+pre-trained backbone.
+
+This is *just* the inference-side primitive. Training a projection
+requires gradient infra not in scope here — load pre-trained weights via
+:meth:`from_json` / :meth:`load`, or hand-set ``weight``/``bias`` after
+construction to plug in trained values.
+
+Glorot uniform initialisation by default with a caller-supplied seed,
+so the same seed produces identical untrained weights — useful for
+deterministic-baseline comparisons and CI sanity checks.
+
+Stdlib + numpy.
+
+Goal-list ties: Conditioning bridge projection layer (direct),
+Soft prompt or adapter injection (small linear adapters are this shape).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional, Union
+
+import numpy as np
+
+
+class LinearProjection:
+    """``y = x @ W + b`` for embedding-space bridging.
+
+    Parameters
+    ----------
+    in_dim, out_dim:
+        Input and output dimensions; both must be > 0.
+    seed:
+        Optional integer seed for the Glorot-uniform initialiser. Same
+        seed → same starting weights.
+    """
+
+    def __init__(self, in_dim: int, out_dim: int, seed: Optional[int] = None) -> None:
+        if in_dim <= 0 or out_dim <= 0:
+            raise ValueError("in_dim and out_dim must both be > 0")
+        self._in_dim = int(in_dim)
+        self._out_dim = int(out_dim)
+        rng = np.random.default_rng(seed)
+        # Glorot uniform: U[-limit, +limit] with limit = sqrt(6 / (in + out)).
+        limit = float(np.sqrt(6.0 / (in_dim + out_dim)))
+        self.weight: np.ndarray = rng.uniform(-limit, limit, size=(in_dim, out_dim)).astype(
+            np.float32
+        )
+        self.bias: np.ndarray = np.zeros(out_dim, dtype=np.float32)
+
+    # ----------------------------------------------------------------- meta
+    @property
+    def in_dim(self) -> int:
+        return self._in_dim
+
+    @property
+    def out_dim(self) -> int:
+        return self._out_dim
+
+    # --------------------------------------------------------------- apply
+    def apply(self, x: np.ndarray) -> np.ndarray:
+        """Project ``x`` through the affine transform.
+
+        Accepts a single 1-D vector of length ``in_dim`` or a 2-D batch of
+        shape ``(N, in_dim)``. Returns matching rank: 1-D → 1-D, 2-D → 2-D.
+        """
+        x = np.asarray(x, dtype=np.float32)
+        if x.ndim == 1:
+            if x.shape[0] != self._in_dim:
+                raise ValueError(
+                    f"input dim {x.shape[0]} != expected {self._in_dim}"
+                )
+            return (x @ self.weight + self.bias).astype(np.float32)
+        if x.ndim == 2:
+            if x.shape[1] != self._in_dim:
+                raise ValueError(
+                    f"input dim {x.shape[1]} != expected {self._in_dim}"
+                )
+            return (x @ self.weight + self.bias).astype(np.float32)
+        raise ValueError(f"expected 1-D or 2-D input; got shape {x.shape}")
+
+    # -------------------------------------------------- serialisation (JSON)
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "in_dim": self._in_dim,
+                "out_dim": self._out_dim,
+                "weight": self.weight.tolist(),
+                "bias": self.bias.tolist(),
+            }
+        )
+
+    @classmethod
+    def from_json(cls, payload: str) -> "LinearProjection":
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"invalid JSON: {e}") from e
+        try:
+            obj = cls(in_dim=int(data["in_dim"]), out_dim=int(data["out_dim"]), seed=0)
+            obj.weight = np.asarray(data["weight"], dtype=np.float32)
+            obj.bias = np.asarray(data["bias"], dtype=np.float32)
+        except (KeyError, TypeError) as e:
+            raise ValueError(f"missing or malformed field: {e}") from e
+        return obj
+
+    def save(self, path: Union[Path, str]) -> None:
+        Path(path).write_text(self.to_json(), encoding="utf-8")
+
+    @classmethod
+    def load(cls, path: Union[Path, str]) -> "LinearProjection":
+        return cls.from_json(Path(path).read_text(encoding="utf-8"))

--- a/tests/unit/test_linear_projection.py
+++ b/tests/unit/test_linear_projection.py
@@ -1,0 +1,122 @@
+"""LinearProjection — small affine bridge between embedding spaces.
+
+Goal: Conditioning bridge projection layer (direct),
+Soft prompt or adapter injection (small projections are the adapter shape)."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from music_brain.latent.projection import LinearProjection
+
+
+# ---------------------------------------------------------------------------
+# Construction & shape
+# ---------------------------------------------------------------------------
+
+
+def test_projection_shape_matches_constructor_args():
+    proj = LinearProjection(in_dim=8, out_dim=4, seed=0)
+    assert proj.weight.shape == (8, 4)
+    assert proj.bias.shape == (4,)
+
+
+def test_projection_seed_is_deterministic():
+    a = LinearProjection(in_dim=4, out_dim=2, seed=42)
+    b = LinearProjection(in_dim=4, out_dim=2, seed=42)
+    np.testing.assert_array_equal(a.weight, b.weight)
+    np.testing.assert_array_equal(a.bias, b.bias)
+
+
+def test_projection_different_seeds_differ():
+    a = LinearProjection(in_dim=4, out_dim=2, seed=0)
+    b = LinearProjection(in_dim=4, out_dim=2, seed=1)
+    # Extremely unlikely to coincide given Glorot init scale.
+    assert not np.allclose(a.weight, b.weight)
+
+
+def test_invalid_dims_raise():
+    with pytest.raises(ValueError):
+        LinearProjection(in_dim=0, out_dim=4)
+    with pytest.raises(ValueError):
+        LinearProjection(in_dim=4, out_dim=0)
+
+
+# ---------------------------------------------------------------------------
+# apply
+# ---------------------------------------------------------------------------
+
+
+def test_apply_single_vector_returns_projected_shape():
+    proj = LinearProjection(in_dim=4, out_dim=2, seed=0)
+    x = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32)
+    y = proj.apply(x)
+    assert y.shape == (2,)
+
+
+def test_apply_batch_returns_projected_batch_shape():
+    proj = LinearProjection(in_dim=4, out_dim=2, seed=0)
+    batch = np.ones((5, 4), dtype=np.float32)
+    y = proj.apply(batch)
+    assert y.shape == (5, 2)
+
+
+def test_apply_input_dim_mismatch_raises():
+    proj = LinearProjection(in_dim=4, out_dim=2, seed=0)
+    bad = np.zeros(3, dtype=np.float32)
+    with pytest.raises(ValueError, match="dim"):
+        proj.apply(bad)
+
+
+def test_apply_uses_weight_and_bias():
+    """Set known weight/bias and verify apply == x @ W + b."""
+    proj = LinearProjection(in_dim=2, out_dim=3, seed=0)
+    proj.weight = np.array([[1.0, 0.0, -1.0], [0.0, 1.0, 1.0]], dtype=np.float32)
+    proj.bias = np.array([0.5, 0.5, 0.5], dtype=np.float32)
+    y = proj.apply(np.array([1.0, 2.0], dtype=np.float32))
+    # x @ W: [1*1+2*0, 1*0+2*1, 1*(-1)+2*1] = [1, 2, 1]
+    # + bias: [1.5, 2.5, 1.5]
+    assert y == pytest.approx([1.5, 2.5, 1.5])
+
+
+# ---------------------------------------------------------------------------
+# JSON round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_to_json_and_from_json_round_trip():
+    a = LinearProjection(in_dim=4, out_dim=2, seed=7)
+    payload = a.to_json()
+    b = LinearProjection.from_json(payload)
+    np.testing.assert_allclose(a.weight, b.weight, rtol=1e-6)
+    np.testing.assert_allclose(a.bias, b.bias, rtol=1e-6)
+
+
+def test_from_json_with_invalid_payload_raises():
+    with pytest.raises(ValueError):
+        LinearProjection.from_json("not-json")
+
+
+def test_save_load_round_trip(tmp_path: Path):
+    a = LinearProjection(in_dim=4, out_dim=2, seed=7)
+    a.save(tmp_path / "proj.json")
+    b = LinearProjection.load(tmp_path / "proj.json")
+    np.testing.assert_allclose(a.weight, b.weight, rtol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Glorot init magnitude sanity
+# ---------------------------------------------------------------------------
+
+
+def test_glorot_init_keeps_variance_in_reasonable_range():
+    """Glorot variance ~ 2/(in+out). For 64x64 → ~0.03; std ~ 0.17.
+    We don't assert exact theoretical variance, just that values are
+    bounded and non-uniform."""
+    proj = LinearProjection(in_dim=64, out_dim=64, seed=0)
+    flat = proj.weight.flatten()
+    # No value should explode; Glorot keeps values bounded.
+    assert np.max(np.abs(flat)) < 2.0
+    # Variance is nonzero (not all the same value).
+    assert flat.std() > 1e-4


### PR DESCRIPTION
## Summary

A weights+bias pair plus \`apply\` / \`save\` / \`load\`. Used wherever the music brain stack needs to glue two embedding spaces of different dimensions — e.g. conditioning a 256-d intent representation into a 384-d audio encoder's input space, or attaching a low-rank adapter on top of a pre-trained backbone.

**Inference-side only** — training requires gradient infra not in scope. Load pre-trained weights via \`from_json\` / \`load\`, or hand-set \`weight\`/\`bias\` after construction to plug in trained values.

Advances two goal-list items:
- **Conditioning bridge projection layer** (direct)
- **Soft prompt or adapter injection** (small linear adapters are this shape)

## API

\`\`\`python
from music_brain.latent.projection import LinearProjection

proj = LinearProjection(in_dim=256, out_dim=384, seed=42)
proj.apply(intent_embedding)       # 1-D input → 1-D output
proj.apply(batch_of_embeddings)    # (N, 256) → (N, 384)
proj.save("/tmp/bridge.json")
\`\`\`

Glorot-uniform initialisation by default with a caller-supplied seed, so the same seed produces identical untrained weights — useful for deterministic-baseline comparisons and CI sanity checks.

## Tests

12 TDD-driven tests in \`tests/unit/test_linear_projection.py\` covering: shape, seed determinism, seed independence, invalid dims, single-vector apply, batch apply, dim-mismatch raise, exact \`W·x + b\` math, JSON round-trip, invalid JSON raise, save/load round-trip, Glorot variance bounds.

## Test plan

- [x] \`pytest tests/unit/test_linear_projection.py\` — 12/12
- [ ] CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new self-contained utility class and unit tests without modifying existing runtime paths beyond a new module export.
> 
> **Overview**
> Adds a new `music_brain.latent` module exporting `LinearProjection`, a small NumPy-based affine projection (`y = x @ W + b`) for bridging embedding dimensions with deterministic Glorot-uniform initialization.
> 
> Includes JSON serialization/deserialization plus `save`/`load` helpers, and a new unit test suite covering shape/determinism, input validation, apply behavior for vector/batch inputs, and JSON/file round-trips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85a1c292af7edf31ba4af3e00a23c0a71dbd5dc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->