### PR TITLE
fix(ci): add httpx to Python Tests job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         pip install -e .
         pip install numpy scipy torch librosa pyyaml
-        pip install pytest pytest-cov coverage
+        pip install pytest pytest-cov coverage httpx
     - name: Sync canonical entity contracts
       run: |
         python3 scripts/sync_entities.py


### PR DESCRIPTION
## Summary

- `ci.yml::python_tests` installed deps manually but was missing `httpx`, which `fastapi.testclient.TestClient` requires. This caused `tests/unit/test_api_audit_fixes.py` to fail across the entire in-flight feature wave (#185–#195) even though none of those PRs touch the API.
- `ci-python.yml` already installs `.[dev]` (which includes httpx), so this brings `ci.yml`'s manual list into parity for that one dep.

## Why this matters

Unblocks the 11-PR feature wave from spurious red CI on shared infra they have no causal relationship to.

## Out of scope

Unifying the two Python-test jobs (`ci.yml::python_tests` vs `ci-python.yml::Python Tests`) — left as a follow-up.

## Test plan

- [ ] Python Tests job goes green on this PR
- [ ] Rebase one wave PR (e.g. #194) onto this fix and confirm Python Tests goes green there too

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that adds a missing test dependency; no production code or behavior is modified.
> 
> **Overview**
> Fixes failing GitHub Actions `python_tests` runs by adding `httpx` to the explicit `pip install` list in `.github/workflows/ci.yml`, aligning the job with dependencies required by `fastapi.testclient.TestClient` used in unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 901cc6e55d368ecf7564ba5d57b425e390e01aaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->