### PR TITLE
feat(xformat): pre-merge verification gate against agentic-coding regressions

### DIFF
--- a/docs/XFORMAT.md
+++ b/docs/XFORMAT.md
@@ -1,0 +1,74 @@
+# xformat — pre-merge verification gate
+
+`xformat` is a guardrail against agentic-coding regressions. Before a branch is
+pushed or merged, it runs the checks that catch the failure modes an autonomous
+agent is most likely to introduce — lint/type regressions, broken tests, schema
+drift, and edits that stray outside the task's declared scope.
+
+It exists because automated agents *do* drift: the 2026-05-23 swarm run produced
+feature branches off a stale base, two of which re-implemented code that had
+already landed on `main` (see `docs/MERGE_PLAN_2026-05-23.md`). `xformat` is the
+gate that would have flagged that before the work was proposed.
+
+## Checks
+
+Every check is scoped to *what actually changed* and SKIPs when irrelevant, so
+the gate stays fast on small diffs.
+
+| Check | Runs when | What it does |
+|-------|-----------|--------------|
+| `scope` | `--scope` declared | Changed files must match an allowed glob; out-of-scope edits FAIL |
+| `lint` | `.py` changed | `flake8 --max-line-length 100` on changed Python files |
+| `typecheck` | `.ts`/`.tsx` changed | `npx tsc --noEmit` |
+| `tests` | test files / mapped modules changed | `pytest` on changed + affected tests (`--full` = whole suite) |
+| `rust` | `engine/intent_ir/**.rs` changed | `cargo check` (`--full` = `cargo test`) |
+| `schema` | `shared_schemas/**` or `engine_api/schema*` changed | regenerates via `sync_entities.py`, then git-diffs the generated mirrors; drift = FAIL (tree is restored either way) |
+| `gitnexus` | always | `gitnexus status` freshness — WARN only |
+
+Exit code: **0** when every check is PASS / SKIP / WARN, **1** when any FAILs.
+
+### GitNexus caveat
+
+`gitnexus impact` and `gitnexus detect_changes` are **MCP tools with no CLI**, so
+they cannot run inside a shell hook. They remain an **agent-time obligation**
+(see `CLAUDE.md` → "Always Do"). The `gitnexus` check here only flags a *stale
+index*, which would make any agent-side impact analysis unreliable.
+
+## Usage
+
+```bash
+# Diff against origin/main (default), affected checks only
+python3 scripts/xformat.py
+
+# Enforce a scope allowlist (mirrors a subagent's declared file boundary)
+python3 scripts/xformat.py --scope 'music_brain/latent/**' --scope 'tests/unit/**'
+
+# Include uncommitted + untracked files, not just base...HEAD
+python3 scripts/xformat.py --include-dirty
+
+# Whole pytest suite / cargo test instead of only affected targets
+python3 scripts/xformat.py --full
+
+# Diff against a different base
+python3 scripts/xformat.py --base origin/feat/some-branch
+```
+
+## Install as a pre-push hook (opt-in)
+
+The hooks in `scripts/hooks/` chain Git LFS (preserved) and the xformat gate.
+Enable them per-clone:
+
+```bash
+git config core.hooksPath scripts/hooks      # enable
+git config --unset core.hooksPath            # disable
+```
+
+Bypass for a single push (e.g. a WIP branch):
+
+```bash
+XFORMAT_SKIP=1 git push      # or: git push --no-verify
+```
+
+`scripts/hooks/` also ships forwarding stubs for `post-commit`, `post-merge`, and
+`post-checkout` so that redirecting `core.hooksPath` does not disable the Git LFS
+hooks the repo relies on.

--- a/scripts/hooks/post-checkout
+++ b/scripts/hooks/post-checkout
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Forwarding stub: when core.hooksPath=scripts/hooks, this preserves Git LFS.
+command -v git-lfs >/dev/null 2>&1 && git lfs post-checkout "$@"
+exit 0

--- a/scripts/hooks/post-commit
+++ b/scripts/hooks/post-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Forwarding stub: when core.hooksPath=scripts/hooks, this preserves Git LFS.
+command -v git-lfs >/dev/null 2>&1 && git lfs post-commit "$@"
+exit 0

--- a/scripts/hooks/post-merge
+++ b/scripts/hooks/post-merge
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Forwarding stub: when core.hooksPath=scripts/hooks, this preserves Git LFS.
+command -v git-lfs >/dev/null 2>&1 && git lfs post-merge "$@"
+exit 0

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,0 +1,36 @@
+#!/bin/sh
+# xformat pre-push hook — chains Git LFS (preserved) then the xformat gate.
+#
+# Install (opt-in), from the repo root:
+#     git config core.hooksPath scripts/hooks
+# Uninstall:
+#     git config --unset core.hooksPath
+#
+# Bypass for a single push (e.g. WIP branch):  git push --no-verify
+#
+# Setting core.hooksPath redirects ALL hooks here, so this script must keep
+# running the LFS hooks the repo relies on. Only pre-push gates on xformat;
+# the rest just forward to LFS.
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# --- Git LFS (matches the stock .git/hooks/pre-push) ---
+if command -v git-lfs >/dev/null 2>&1; then
+    git lfs pre-push "$@" || exit $?
+fi
+
+# --- xformat gate ---
+if [ "${XFORMAT_SKIP:-}" = "1" ]; then
+    echo "xformat: skipped (XFORMAT_SKIP=1)" >&2
+    exit 0
+fi
+
+python3 "$REPO_ROOT/scripts/xformat.py" --base origin/main
+status=$?
+if [ "$status" -ne 0 ]; then
+    echo "" >&2
+    echo "xformat gate failed — push blocked. Fix the items above, or bypass with:" >&2
+    echo "    XFORMAT_SKIP=1 git push        (or: git push --no-verify)" >&2
+    exit "$status"
+fi
+exit 0

--- a/scripts/xformat.py
+++ b/scripts/xformat.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""xformat — pre-merge verification gate.
+
+A guardrail against agentic-coding regressions. Before a branch is pushed or
+merged, ``xformat`` runs the checks that catch the failure modes an autonomous
+agent is most likely to introduce: lint/type regressions, broken tests, schema
+drift between the canonical contract and its generated mirrors, and edits that
+stray outside the task's declared scope.
+
+Each check is *scoped to what actually changed* and SKIPs when irrelevant, so
+the gate stays fast on small diffs:
+
+  - scope     changed files must match the declared --scope allowlist
+  - lint      flake8 on changed Python files
+  - typecheck ``tsc --noEmit`` when TS/TSX changed
+  - tests     pytest on changed + affected test files (--full = whole suite)
+  - rust      ``cargo check`` when engine/intent_ir Rust changed
+  - schema    regenerate via sync_entities.py, then git-diff the generated
+              mirrors; drift = FAIL
+  - gitnexus  ``gitnexus status`` freshness warning. NOTE: gitnexus impact /
+              detect_changes are MCP tools with no CLI, so they cannot run from
+              a shell hook — they remain an *agent-time* obligation (see
+              CLAUDE.md "Always Do"). This check only flags a stale index,
+              which would make any agent-side impact analysis unreliable.
+
+Exit code: 0 when every check is PASS / SKIP / WARN; 1 when any check FAILs.
+
+Run manually:   python3 scripts/xformat.py --base origin/main
+With scope:     python3 scripts/xformat.py --scope 'music_brain/latent/**' --scope 'tests/unit/**'
+Whole suite:    python3 scripts/xformat.py --full
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Generated mirrors that sync_entities.py owns. Drift in any of these means the
+# committed contract is out of sync with the canonical Python schema.
+SCHEMA_SOURCE_GLOBS = (
+    "shared_schemas/*",
+    "music_brain/engine_api/schema.py",
+    "music_brain/engine_api/schema/*",
+)
+SCHEMA_GENERATED_PATHS = (
+    "src/types/Intent.ts",
+    "src/types/EmotionState.ts",
+    "src/types/IntentFrame.ts",
+    "engine/intent_ir/src/generated/intent.rs",
+    "engine/intent_ir/src/generated/emotion.rs",
+    "engine/intent_ir/src/generated/intent_frame.rs",
+)
+
+PASS, FAIL, SKIP, WARN = "PASS", "FAIL", "SKIP", "WARN"
+
+
+@dataclass
+class Result:
+    name: str
+    status: str
+    detail: str = ""
+
+
+def _run(cmd: Sequence[str], cwd: Path = REPO_ROOT) -> subprocess.CompletedProcess:
+    """Run *cmd*, capturing output. Never raises on non-zero exit."""
+    return subprocess.run(
+        list(cmd), cwd=str(cwd), capture_output=True, text=True, check=False
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers (unit-tested directly)
+# --------------------------------------------------------------------------- #
+def scope_violations(files: Iterable[str], patterns: Sequence[str]) -> List[str]:
+    """Return changed *files* that match none of the allowed glob *patterns*.
+
+    Empty *patterns* means "no scope declared" — the caller treats that as a
+    SKIP rather than a violation.
+    """
+    if not patterns:
+        return []
+    out: List[str] = []
+    for f in files:
+        if not any(fnmatch.fnmatch(f, p) for p in patterns):
+            out.append(f)
+    return out
+
+
+def _matches_any(path: str, globs: Sequence[str]) -> bool:
+    return any(fnmatch.fnmatch(path, g) for g in globs)
+
+
+@dataclass
+class Classification:
+    py: List[str]
+    ts: List[str]
+    rust: List[str]
+    cpp: List[str]
+    schema: List[str]
+    test_files: List[str]
+    affected_tests: List[str]
+
+
+def classify(files: Sequence[str]) -> Classification:
+    """Bucket changed *files* by the check that cares about them."""
+    py = [f for f in files if f.endswith(".py")]
+    ts = [f for f in files if f.endswith((".ts", ".tsx"))]
+    rust = [f for f in files if f.endswith(".rs") and f.startswith("engine/intent_ir/")]
+    cpp = [f for f in files if f.endswith((".cpp", ".cc", ".cxx", ".h", ".hpp", ".inl"))]
+    schema = [f for f in files if _matches_any(f, SCHEMA_SOURCE_GLOBS)]
+
+    test_files = [
+        f
+        for f in py
+        if f.startswith("tests/") and Path(f).name.startswith("test_")
+    ]
+    # Map a changed module music_brain/x/y.py -> tests/unit/test_y.py when it exists.
+    affected: List[str] = []
+    for f in py:
+        if f in test_files or not f.startswith("music_brain/"):
+            continue
+        candidate = f"tests/unit/test_{Path(f).stem}.py"
+        if (REPO_ROOT / candidate).exists() and candidate not in affected:
+            affected.append(candidate)
+    return Classification(py, ts, rust, cpp, schema, test_files, affected)
+
+
+# --------------------------------------------------------------------------- #
+# Git plumbing
+# --------------------------------------------------------------------------- #
+def changed_files(base: str, include_dirty: bool) -> List[str]:
+    """Files changed relative to *base* (merge-base diff), plus optionally the
+    uncommitted working-tree + untracked files."""
+    files: set[str] = set()
+    cp = _run(["git", "diff", "--name-only", f"{base}...HEAD"])
+    if cp.returncode == 0:
+        files.update(line for line in cp.stdout.splitlines() if line.strip())
+    if include_dirty:
+        for args in (["git", "diff", "--name-only"], ["git", "diff", "--name-only", "--cached"]):
+            cp = _run(args)
+            files.update(line for line in cp.stdout.splitlines() if line.strip())
+        cp = _run(["git", "ls-files", "--others", "--exclude-standard"])
+        files.update(line for line in cp.stdout.splitlines() if line.strip())
+    return sorted(files)
+
+
+# --------------------------------------------------------------------------- #
+# Checks
+# --------------------------------------------------------------------------- #
+def check_scope(files: Sequence[str], patterns: Sequence[str]) -> Result:
+    if not patterns:
+        return Result("scope", SKIP, "no --scope declared")
+    bad = scope_violations(files, patterns)
+    if bad:
+        shown = ", ".join(bad[:5]) + (" …" if len(bad) > 5 else "")
+        return Result("scope", FAIL, f"{len(bad)} file(s) outside scope: {shown}")
+    return Result("scope", PASS, f"{len(files)} file(s) within scope")
+
+
+def check_lint(cls: Classification) -> Result:
+    if not cls.py:
+        return Result("lint", SKIP, "no Python changes")
+    cp = _run(["python3", "-m", "flake8", "--max-line-length", "100", *cls.py])
+    if cp.returncode != 0:
+        n = len([ln for ln in cp.stdout.splitlines() if ln.strip()])
+        return Result("lint", FAIL, f"{n} flake8 finding(s)\n{cp.stdout.strip()}")
+    return Result("lint", PASS, f"flake8 clean on {len(cls.py)} file(s)")
+
+
+def check_typecheck(cls: Classification) -> Result:
+    if not cls.ts:
+        return Result("typecheck", SKIP, "no TS/TSX changes")
+    cp = _run(["npx", "tsc", "--noEmit"])
+    if cp.returncode != 0:
+        return Result("typecheck", FAIL, (cp.stdout or cp.stderr).strip()[-2000:])
+    return Result("typecheck", PASS, "tsc --noEmit clean")
+
+
+def check_tests(cls: Classification, full: bool) -> Result:
+    if full:
+        targets = ["tests/"]
+    else:
+        targets = sorted(set(cls.test_files) | set(cls.affected_tests))
+    if not targets:
+        return Result("tests", SKIP, "no test files changed/affected")
+    cp = _run(["python3", "-m", "pytest", *targets, "-q", "-x"])
+    if cp.returncode != 0:
+        tail = (cp.stdout or cp.stderr).strip().splitlines()[-25:]
+        return Result("tests", FAIL, "\n".join(tail))
+    return Result("tests", PASS, f"pytest green ({len(targets)} target(s))")
+
+
+def check_rust(cls: Classification, full: bool) -> Result:
+    if not cls.rust:
+        return Result("rust", SKIP, "no engine/intent_ir Rust changes")
+    crate = REPO_ROOT / "engine" / "intent_ir"
+    cmd = ["cargo", "test"] if full else ["cargo", "check"]
+    cp = _run(cmd, cwd=crate)
+    if cp.returncode != 0:
+        return Result("rust", FAIL, (cp.stderr or cp.stdout).strip()[-1500:])
+    return Result("rust", PASS, f"{' '.join(cmd)} clean")
+
+
+def check_schema_drift(cls: Classification) -> Result:
+    if not cls.schema:
+        return Result("schema", SKIP, "no schema sources changed")
+    gen = _run(["python3", "scripts/sync_entities.py"])
+    if gen.returncode != 0:
+        msg = (gen.stderr or gen.stdout).strip()[-1200:]
+        return Result("schema", FAIL, "sync_entities.py failed:\n" + msg)
+    existing = [p for p in SCHEMA_GENERATED_PATHS if (REPO_ROOT / p).exists()]
+    diff = _run(["git", "diff", "--name-only", "--", *existing])
+    drifted = [ln for ln in diff.stdout.splitlines() if ln.strip()]
+    if drifted:
+        # Restore so the gate leaves the tree as it found it.
+        _run(["git", "checkout", "--", *drifted])
+        return Result(
+            "schema",
+            FAIL,
+            "generated mirrors drifted from schema — run scripts/sync_entities.py and commit:\n  "
+            + "\n  ".join(drifted),
+        )
+    return Result("schema", PASS, "generated mirrors in sync")
+
+
+def check_gitnexus() -> Result:
+    cp = _run(["npx", "gitnexus", "status"])
+    out = (cp.stdout + cp.stderr).lower()
+    if cp.returncode != 0:
+        return Result("gitnexus", WARN, "gitnexus status unavailable (index/CLI missing)")
+    if "stale" in out or "out of date" in out or "out-of-date" in out:
+        return Result("gitnexus", WARN,
+                      "index STALE — run `npx gitnexus analyze`; "
+                      "agent impact analysis unreliable until then")
+    return Result("gitnexus", PASS,
+                  "index fresh (run gitnexus_impact/detect_changes as agent-time steps)")
+
+
+# --------------------------------------------------------------------------- #
+# Reporting
+# --------------------------------------------------------------------------- #
+_GLYPH = {PASS: "✓", FAIL: "✗", SKIP: "·", WARN: "!"}
+
+
+def render(results: Sequence[Result]) -> str:
+    width = max((len(r.name) for r in results), default=4)
+    lines = ["", "  xformat — pre-merge verification gate", ""]
+    for r in results:
+        head = r.detail.splitlines()[0] if r.detail else ""
+        lines.append(f"  {_GLYPH.get(r.status, '?')} {r.status:<4} {r.name:<{width}}  {head}")
+        extra = r.detail.splitlines()[1:] if r.detail else []
+        for ln in extra:
+            lines.append(f"        {ln}")
+    failed = [r.name for r in results if r.status == FAIL]
+    lines.append("")
+    lines.append("  RESULT: " + ("FAIL → " + ", ".join(failed) if failed else "PASS"))
+    lines.append("")
+    return "\n".join(lines)
+
+
+def run_gate(base: str, scope: Sequence[str], include_dirty: bool, full: bool) -> int:
+    files = changed_files(base, include_dirty)
+    cls = classify(files)
+    results = [
+        check_scope(files, scope),
+        check_lint(cls),
+        check_typecheck(cls),
+        check_tests(cls, full),
+        check_rust(cls, full),
+        check_schema_drift(cls),
+        check_gitnexus(),
+    ]
+    sys.stdout.write(render(results))
+    return 1 if any(r.status == FAIL for r in results) else 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(prog="xformat", description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--base", default="origin/main",
+                    help="ref to diff against (default: origin/main)")
+    ap.add_argument("--scope", action="append", default=[], metavar="GLOB",
+                    help="allowed path glob; repeatable. Files outside all globs FAIL scope.")
+    ap.add_argument("--include-dirty", action="store_true",
+                    help="also check uncommitted + untracked files, not just base...HEAD")
+    ap.add_argument("--full", action="store_true",
+                    help="run the whole pytest suite / cargo test instead of only affected targets")
+    args = ap.parse_args(argv)
+    return run_gate(args.base, args.scope, args.include_dirty, args.full)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_xformat.py
+++ b/tests/unit/test_xformat.py
@@ -1,0 +1,119 @@
+"""Unit tests for the xformat pre-merge verification gate (scripts/xformat.py)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+_XFORMAT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "xformat.py"
+
+
+def _load_xformat():
+    spec = importlib.util.spec_from_file_location("xformat", _XFORMAT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    # Register before exec: @dataclass resolution looks the module up in
+    # sys.modules (Python 3.12+/3.14), which fails for an unregistered module.
+    sys.modules["xformat"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+xf = _load_xformat()
+
+
+# --------------------------- scope_violations --------------------------- #
+def test_scope_no_patterns_means_no_violations():
+    assert xf.scope_violations(["music_brain/anything.py"], []) == []
+
+
+def test_scope_all_within():
+    files = ["music_brain/latent/projection.py", "tests/unit/test_projection.py"]
+    patterns = ["music_brain/latent/**", "tests/unit/**"]
+    assert xf.scope_violations(files, patterns) == []
+
+
+def test_scope_flags_out_of_scope_file():
+    files = ["music_brain/latent/projection.py", "engine/intent_ir/src/lib.rs"]
+    patterns = ["music_brain/latent/**"]
+    assert xf.scope_violations(files, patterns) == ["engine/intent_ir/src/lib.rs"]
+
+
+def test_check_scope_skips_without_patterns():
+    res = xf.check_scope(["a.py"], [])
+    assert res.status == xf.SKIP
+
+
+def test_check_scope_fails_on_violation():
+    res = xf.check_scope(["src/main.tsx"], ["music_brain/**"])
+    assert res.status == xf.FAIL
+    assert "src/main.tsx" in res.detail
+
+
+# ------------------------------ classify -------------------------------- #
+def test_classify_buckets_by_extension():
+    files = [
+        "music_brain/latent/projection.py",
+        "src/types/Intent.ts",
+        "src/App.tsx",
+        "engine/intent_ir/src/lib.rs",
+        "engine/kelly_core.cpp",
+        "shared_schemas/CompleteSongIntentRequest.json",
+        "tests/unit/test_projection.py",
+    ]
+    cls = xf.classify(files)
+    assert "music_brain/latent/projection.py" in cls.py
+    assert set(cls.ts) == {"src/types/Intent.ts", "src/App.tsx"}
+    assert cls.rust == ["engine/intent_ir/src/lib.rs"]
+    assert cls.cpp == ["engine/kelly_core.cpp"]
+    assert "shared_schemas/CompleteSongIntentRequest.json" in cls.schema
+    assert cls.test_files == ["tests/unit/test_projection.py"]
+
+
+def test_classify_rust_only_counts_intent_ir():
+    cls = xf.classify(["engine/other/foo.rs", "engine/intent_ir/src/lib.rs"])
+    assert cls.rust == ["engine/intent_ir/src/lib.rs"]
+
+
+def test_classify_affected_tests_maps_existing_only(tmp_path, monkeypatch):
+    # This test module itself exists, so a changed music_brain/xformat-like
+    # module name that has no matching test maps to nothing.
+    cls = xf.classify(["music_brain/does_not_exist_module.py"])
+    assert cls.affected_tests == []
+
+
+# ------------------------------ rendering ------------------------------- #
+def test_render_reports_pass_when_no_failures():
+    out = xf.render([xf.Result("lint", xf.PASS, "clean"), xf.Result("tests", xf.SKIP)])
+    assert "RESULT: PASS" in out
+
+
+def test_render_reports_failed_check_names():
+    out = xf.render([xf.Result("lint", xf.FAIL, "2 findings"), xf.Result("tests", xf.PASS)])
+    assert "RESULT: FAIL" in out
+    assert "lint" in out
+
+
+# --------------------------- check behaviours --------------------------- #
+def test_check_lint_skips_without_python(monkeypatch):
+    cls = xf.classify(["src/App.tsx"])
+    assert xf.check_lint(cls).status == xf.SKIP
+
+
+def test_check_schema_drift_skips_without_schema_changes():
+    cls = xf.classify(["music_brain/latent/projection.py"])
+    assert xf.check_schema_drift(cls).status == xf.SKIP
+
+
+def test_check_tests_skips_when_no_targets():
+    cls = xf.classify(["music_brain/no_matching_test.py"])
+    assert xf.check_tests(cls, full=False).status == xf.SKIP
+
+
+def test_main_returns_int(monkeypatch):
+    # Drive main() with a base that yields no diff -> all SKIP -> exit 0.
+    monkeypatch.setattr(xf, "changed_files", lambda base, include_dirty: [])
+    monkeypatch.setattr(xf, "check_gitnexus", lambda: xf.Result("gitnexus", xf.SKIP))
+    assert xf.main(["--base", "HEAD"]) == 0


### PR DESCRIPTION
## What

`xformat` is a guardrail against agentic-coding regressions — a scoped verification gate that runs on what a branch *changes* before it is pushed or merged.

It exists because automated agents drift: the 2026-05-23 swarm run produced feature branches off a stale base, two of which re-implemented code already on `main` (see `docs/MERGE_PLAN_2026-05-23.md`). `xformat` is the gate that would have flagged that.

## Checks

Each check is scoped to what actually changed and SKIPs when irrelevant, so the gate stays fast on small diffs.

| Check | Runs when | Action |
|-------|-----------|--------|
| `scope` | `--scope` declared | changed files must match an allowed glob; out-of-scope edits FAIL |
| `lint` | `.py` changed | `flake8 --max-line-length 100` on changed files |
| `typecheck` | `.ts`/`.tsx` changed | `npx tsc --noEmit` |
| `tests` | tests / mapped modules changed | `pytest` on changed + affected tests (`--full` = whole suite) |
| `rust` | `engine/intent_ir/**.rs` changed | `cargo check` (`--full` = `cargo test`) |
| `schema` | `shared_schemas/**` or `engine_api/schema*` changed | regenerate via `sync_entities.py`, git-diff the mirrors; drift = FAIL (tree restored) |
| `gitnexus` | always | `gitnexus status` freshness — WARN only |

Exit code: **0** when every check is PASS/SKIP/WARN, **1** when any FAILs.

### GitNexus caveat
`gitnexus impact` / `detect_changes` are **MCP-only (no CLI)**, so they can't run in a shell hook — they remain an agent-time obligation (per `CLAUDE.md`). The `gitnexus` check here only flags a stale index.

## Files
- `scripts/xformat.py` — the gate (testable helpers + CLI)
- `scripts/hooks/` — opt-in pre-push hook chaining Git LFS + xformat, with LFS forwarding stubs so a `core.hooksPath` redirect doesn't disable LFS
- `tests/unit/test_xformat.py` — 14 unit tests
- `docs/XFORMAT.md` — checks, usage, hook install, caveat

## Install (opt-in)
```bash
git config core.hooksPath scripts/hooks      # enable
git config --unset core.hooksPath            # disable
XFORMAT_SKIP=1 git push                       # bypass once
```

## Verification
- `flake8 --max-line-length 100` clean on `scripts/xformat.py` + `tests/unit/test_xformat.py`
- `14/14` pytest pass
- Live runs exercised PASS / FAIL(scope) / SKIP / WARN and exit codes 0 and 1
- No C++/CMake in this change (Python + shell + docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New tooling and opt-in hooks only; no production runtime or auth/data-path changes, though schema check mutates then restores generated files on failure.
> 
> **Overview**
> Introduces **`xformat`**, a diff-scoped pre-merge/pre-push verification gate aimed at agentic-coding regressions (scope creep, lint/type/test failures, schema mirror drift).
> 
> **`scripts/xformat.py`** discovers files changed vs a base ref (default `origin/main`, optional dirty/untracked), classifies them, and runs only relevant checks: optional **`--scope`** glob enforcement, **flake8** on touched Python, **`tsc --noEmit`** on TS/TSX, targeted **pytest** (or **`--full`** suite), **`cargo check`/`test`** for `engine/intent_ir` Rust, **schema drift** via `sync_entities.py` plus git-diff of generated mirrors (restores the tree on failure), and a **gitnexus status** freshness **WARN**. Exit **1** if any check **FAIL**s.
> 
> Adds **opt-in `scripts/hooks/`**: **`pre-push`** runs Git LFS then `xformat` (bypass via `XFORMAT_SKIP=1` or `--no-verify`); **post-commit/post-merge/post-checkout** stubs forward to LFS so `core.hooksPath` does not break LFS. **`docs/XFORMAT.md`** documents behavior and install; **`tests/unit/test_xformat.py`** covers scope, classify, render, and skip paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e3f08f594ffd5491d6b131501ea91f98905acff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->