### PR TITLE
fix(ci): install httpx2 so starlette TestClient imports in Python CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         pip install -e .
         pip install numpy scipy torch librosa pyyaml
-        pip install pytest pytest-cov coverage
+        pip install pytest pytest-cov coverage httpx2
     - name: Sync canonical entity contracts
       run: |
         python3 scripts/sync_entities.py

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -44,9 +44,9 @@ jobs:
           python-version: '3.11'
 
       - name: Install dependencies
-        run: |
-          pip install -e .
-          pip install pytest pytest-cov
+        # Test deps (pytest, httpx2 for starlette's TestClient) come from the dev extra
+        # so this job can't drift from pyproject.toml again.
+        run: pip install -e ".[dev]"
 
       - name: Run unit tests
         run: pytest tests/unit/ -v --tb=short

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
     "ruff>=0.1.0",
     "mypy>=1.0",
     "httpx>=0.24",
+    "httpx2>=2.0",
 ]
 audio = [
     "soundfile>=0.12",


### PR DESCRIPTION
## Root cause

\`fastapi>=0.100,<1\` now resolves **fastapi 0.136.3 → starlette 1.2.1**, whose \`testclient\` imports \`httpx2\` (falling back to \`httpx\` with a deprecation warning, hard \`RuntimeError\` if neither is present). The **Python Unit Tests** job in \`pr-review.yml\` installed neither — it ran \`pip install -e .\` + \`pip install pytest pytest-cov\`, never the dev extra — so all 11 TestClient-based tests in \`tests/unit/test_api_audit_fixes.py\` errored at import on every PR (e.g. [run 27269516989](https://github.com/sburdges-eng/KmiDi/actions/runs/27269516989/job/80535104233)).

Local venvs and \`ci-python.yml\` pass because they install \`.[dev]\`, whose \`httpx>=0.24\` satisfies starlette's fallback import. Python 3.11 and submodules were red herrings.

## Fix

- **pr-review.yml**: install \`.[dev]\` instead of an ad-hoc package list, so the test job can't drift from pyproject again
- **pyproject.toml**: add \`httpx2>=2.0\` to the dev extra (starlette's preferred client; avoids the deprecated \`httpx\` fallback)
- **ci.yml**: add \`httpx2\` to the Python Tests job's explicit install (same root cause, same tests)

Resolution pre-verified on Python 3.11: \`httpx2==2.3.0\` + \`httpx==0.28.1\` + \`starlette==1.2.1\` resolve cleanly; prior verification in a clean venv: \`tests/unit/\` → 447 passed, 53 skipped, 0 errors.

## Notes

- \`tests.yml\` has the same gap but is left to #199 (overlaps); #198 proposes an \`httpx\`-only variant of the \`ci.yml\` hunk.
- This PR exists to prove the **Python Unit Tests** check goes green with the fix (pull_request workflows run from the merge commit, so this run uses the fixed install step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 583efc5032372b0fc3f498bd574735b096c11efe. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->