### PR TITLE
feat(agent): add migrated kmidi python agent (ai_core vendored)

### DIFF
--- a/agent/.env.example
+++ b/agent/.env.example
@@ -1,0 +1,5 @@
+# KmiDi — copy to .env and set as needed
+# Optional: audio/MIDI and training paths
+# KMIDI_AUDIO_ROOT=data/audio
+# KMIDI_MIDI_ROOT=data/midi
+# KMIDI_TRAINING_CONFIG=config/training.yaml

--- a/agent/COMPLETION_TODOS.md
+++ b/agent/COMPLETION_TODOS.md
@@ -1,0 +1,32 @@
+# KmiDi completion todos
+
+Check off when done. Use with ROADMAP.md and WORKSPACE.md.
+
+## Phase 1 — Package and modules
+
+- [ ] `kmidi` package exists with `kmidi/__init__.py`, `kmidi/audio.py`, `kmidi/midi.py`.
+- [ ] `uv run pytest apps/kmidi/tests -v` passes with at least one non-placeholder test.
+- [ ] pyproject.toml includes any new deps (e.g. sounddevice, mido, jepa) as needed.
+- [ ] main.py or CLI entry exists and is documented in README.
+
+## Phase 2 — Datasets and config
+
+- [ ] config/datasets.toml (or equivalent) describes dataset paths and splits.
+- [ ] data/README describes expected audio/MIDI data layout.
+- [ ] config/training.yaml stub present for JEPA (or documented as Phase 3).
+
+## Phase 3 — JEPA integration
+
+- [ ] libs/jepa is used for audio embeddings (or integration is documented and deferred).
+- [ ] Training script or entrypoint runs from config (or runbook documents manual steps).
+- [ ] COMPLETION_TODOS for Phase 1–2 all checked.
+
+## Phase 4 — DAW scope (iDAW)
+
+- [ ] daw.py or equivalent scoped; optional transport/project features documented.
+- [ ] Roadmap and completion todos aligned; no critical open items for Phase 1–3.
+
+## Definition of done (release)
+
+- [ ] Phase 1–2 complete; Phase 3 either complete or explicitly deferred with runbook.
+- [ ] README and WORKSPACE.md list only optional/future work for Phase 4.

--- a/agent/Experiments/README.md
+++ b/agent/Experiments/README.md
@@ -1,0 +1,5 @@
+# Experiments
+
+Experimental or one-off tryouts for the kmidi app. Canonical KmiDi experiments live in **Dev/KmiDi/experiments/**; use this for scaffold-specific or monorepo-facing experiments.
+
+**Build and workdir:** Buildable with the **workspace** (run from workspace-scaffold root: `uv sync`, `uv run python apps/kmidi/...`). Do **not** copy the workdir into experiment subfolders. See [../../../EXPERIMENTS_POLICY.md](../../../EXPERIMENTS_POLICY.md) (Dev/EXPERIMENTS_POLICY.md).

--- a/agent/README.md
+++ b/agent/README.md
@@ -1,0 +1,26 @@
+# KmiDi
+
+Audio and DAW tooling app that now includes the iDAW scope. **Not a finished project.**
+
+## Role
+
+KmiDi is the consolidated audio project for composition, MIDI, and DAW-adjacent workflows (KmiDi + iDAW).
+
+## CAD Corpus Reference
+
+CAD corpus context can be referenced when needed at:
+
+- `docs/CAD_CORPUS_SUMMARY.md`
+
+## Build / resolve
+
+From the **workspace root** (parent of `apps/`):
+
+- Resolve deps and build: `uv sync`
+- Run tests: `uv run pytest apps/kmidi/tests -v`
+
+No runnable server yet; this app is a stub for KmiDi + iDAW.
+
+## Auto-apply on open
+
+Resolving the workspace (e.g. `uv sync`) can run automatically when you open the repo. See the **top-level README** at the workspace root for how to enable it.

--- a/agent/ROADMAP.md
+++ b/agent/ROADMAP.md
@@ -1,0 +1,31 @@
+# KmiDi roadmap
+
+## Vision
+
+Audio and DAW app (KmiDi + iDAW): audio I/O, MIDI, optional JEPA-based representations, and a clear path to training/eval configs for audio models.
+
+## Phases
+
+| Phase | Focus | Outcomes |
+|-------|--------|----------|
+| **1** | Package and modules | kmidi package with audio.py, midi.py; pyproject deps; placeholder main or CLI. |
+| **2** | Datasets and config | Dataset config (paths, splits); data/ layout; training config stub for JEPA. |
+| **3** | JEPA integration | Use libs/jepa for audio embeddings; training script or entrypoint; completion todos done. |
+| **4** | DAW scope (iDAW) | Optional daw.py (transport, project); docs and runbook. |
+
+## Milestones
+
+- **M1** — `kmidi` package importable; `uv run pytest apps/kmidi/tests -v` passes with at least one real test.
+- **M2** — config/datasets.toml and config/training.yaml in place; data/README describes expected layout.
+- **M3** — JEPA training runs from config (or documented as manual); completion checklist up to date.
+- **M4** — iDAW scope documented; roadmap and COMPLETION_TODOS aligned.
+
+## Dependencies between apps/libs
+
+- **jepa** (libs/jepa) for audio JEPA training and inference.
+- Optional: **sounddevice**, **mido**, **torch**, **numpy** (add in pyproject when implementing).
+
+## Risks and mitigations
+
+- Audio hardware / latency → document supported backends; make training config point to file-based data first.
+- JEPA not yet implemented → keep training config as stub; Phase 3 depends on libs/jepa TODO.md.

--- a/agent/WORKSPACE.md
+++ b/agent/WORKSPACE.md
@@ -1,0 +1,28 @@
+# KmiDi — structured workspace
+
+## Auto-install on open
+
+When you open this workspace (or the repo root), the **Resolve workspace** task runs `uv sync`, which installs workspace deps. This app is currently a stub (no extra deps beyond root). When you add modules below, add their dependencies to `apps/kmidi/pyproject.toml`; they will be installed automatically on next open. See the **top-level README** for enabling automatic tasks.
+
+## Modules / files to create
+
+| Status   | Module / file              | Description |
+|----------|----------------------------|-------------|
+| Stub     | `tests/test_placeholder.py`| Placeholder test. |
+| To add   | `kmidi/__init__.py`        | Package init. |
+| To add   | `kmidi/audio.py`           | Audio I/O and buffers (e.g. for JEPA or DAW). |
+| To add   | `kmidi/midi.py`            | MIDI in/out or sequencing stubs. |
+| To add   | `kmidi/daw.py`             | Optional: DAW-style transport / project (iDAW scope). |
+| To add   | `main.py`                  | Optional: CLI or server entry. |
+
+## Dependencies to add (in pyproject.toml when needed)
+
+- `jepa` (workspace) if using JEPA for audio representations.
+- Optional: `sounddevice`, `mido`, `numpy`, `torch` for audio/MIDI.
+
+## Todos
+
+- [ ] Add `kmidi` package and `audio` / `midi` modules.
+- [ ] Add `pyproject.toml` dependencies when implementing (e.g. jepa, sounddevice).
+- [ ] Add `main.py` or CLI entry and document in README.
+- [ ] Optional: integrate with libs/jepa for audio embeddings.

--- a/agent/ai_core/__init__.py
+++ b/agent/ai_core/__init__.py
@@ -1,0 +1,1 @@
+"""AI orchestration core."""

--- a/agent/ai_core/interfaces.py
+++ b/agent/ai_core/interfaces.py
@@ -1,0 +1,10 @@
+from abc import ABC
+from typing import Any, Dict
+
+
+class AgentTool(ABC):
+    name: str
+    description: str
+
+    async def execute(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        raise NotImplementedError

--- a/agent/ai_core/orchestrator.py
+++ b/agent/ai_core/orchestrator.py
@@ -1,0 +1,97 @@
+import operator
+from typing import Annotated, Any, Dict, List, TypedDict
+
+from langgraph.graph import END, START, StateGraph
+
+from ai_core.interfaces import AgentTool
+
+
+class AgentState(TypedDict):
+    original_intent: str
+    system_prompt: str
+    chat_history: Annotated[List[Dict[str, str]], operator.add]
+    pending_tool_calls: List[Dict[str, Any]]
+    tool_results: Annotated[List[Dict[str, Any]], operator.add]
+    error_count: int
+
+
+class BaseAgentOrchestrator:
+    def __init__(self, tools: List[AgentTool], system_prompt: str, max_retries: int = 3):
+        self.tool_registry = {tool.name: tool for tool in tools}
+        self.system_prompt = system_prompt
+        self.max_retries = max_retries
+        self.graph = self._build_graph()
+
+    def _build_graph(self):
+        workflow = StateGraph(AgentState)
+        workflow.add_node("reasoning_node", self._reasoning_node)
+        workflow.add_node("tool_executor", self._tool_node)
+        workflow.add_edge(START, "reasoning_node")
+        workflow.add_conditional_edges(
+            "reasoning_node",
+            self._route_execution,
+            {"execute_tools": "tool_executor", "human_fallback": END, "finish": END},
+        )
+        workflow.add_edge("tool_executor", "reasoning_node")
+        return workflow.compile()
+
+    async def _reasoning_node(self, state: AgentState) -> dict:
+        print("[AI CORE] Reasoning Engine Active...")
+        if state.get("error_count", 0) >= self.max_retries:
+            print("[AI CORE] Max retries hit. Halting.")
+            return {"pending_tool_calls": []}
+        if not state.get("tool_results"):
+            return {
+                "pending_tool_calls": [
+                    {
+                        "name": list(self.tool_registry.keys())[0],
+                        "payload": {},
+                    }
+                ]
+            }
+        return {"pending_tool_calls": []}
+
+    async def _tool_node(self, state: AgentState) -> dict:
+        results = []
+        error_increment = 0
+        for call in state["pending_tool_calls"]:
+            tool_name = call.get("name")
+            payload = call.get("payload", {})
+            if tool_name in self.tool_registry:
+                tool = self.tool_registry[tool_name]
+                print(f"[AI CORE] Executing Tool: {tool_name}")
+                result = await tool.execute(payload)
+                results.append({"tool": tool_name, "result": result})
+                if result.get("status") == "error":
+                    error_increment += 1
+            else:
+                results.append(
+                    {
+                        "tool": tool_name,
+                        "result": {"status": "error", "message": "Tool not found."},
+                    }
+                )
+                error_increment += 1
+        return {
+            "pending_tool_calls": [],
+            "tool_results": results,
+            "error_count": state.get("error_count", 0) + error_increment,
+        }
+
+    def _route_execution(self, state: AgentState) -> str:
+        if state.get("error_count", 0) >= self.max_retries:
+            return "human_fallback"
+        if len(state.get("pending_tool_calls", [])) > 0:
+            return "execute_tools"
+        return "finish"
+
+    async def process_intent(self, user_intent: str) -> dict:
+        initial_state = {
+            "original_intent": user_intent,
+            "system_prompt": self.system_prompt,
+            "chat_history": [],
+            "pending_tool_calls": [],
+            "tool_results": [],
+            "error_count": 0,
+        }
+        return await self.graph.ainvoke(initial_state)

--- a/agent/config/datasets.toml
+++ b/agent/config/datasets.toml
@@ -1,0 +1,20 @@
+# KmiDi dataset config (audio / MIDI / JEPA)
+# Paths relative to app or workspace root
+
+[audio]
+# Root directory for audio files (e.g. WAV, FLAC)
+root = "data/audio"
+train_split = "data/audio/train"
+val_split = "data/audio/val"
+# Optional
+# test_split = "data/audio/test"
+
+[midi]
+# MIDI file root (optional)
+root = "data/midi"
+
+[jepa]
+# JEPA training: context/target views or precomputed embeddings
+# Stub; align with libs/jepa once implemented
+# features_dir = "data/jepa_features"
+# manifest_path = "data/splits/train.csv"

--- a/agent/config/training.yaml
+++ b/agent/config/training.yaml
@@ -1,0 +1,43 @@
+# KmiDi JEPA training config (align with libs/jepa when implemented)
+# Stub: copy to training_local.yaml and fill for your runs.
+
+job_name: kmidi-jepa-audio
+
+# Encoder
+encoder:
+  context:
+    type: "cnn"  # or transformer
+    embed_dim: 256
+    # ...
+  target:
+    type: "cnn"
+    embed_dim: 256
+    stop_gradient: true
+
+# Predictor
+predictor:
+  hidden_dims: [512, 256]
+  output_dim: 256
+
+# Loss (e.g. VICReg-style or MSE)
+loss:
+  type: "vicreg"  # or mse
+  lambda_inv: 25.0
+  lambda_var: 25.0
+  lambda_cov: 1.0
+
+# Data (see config/datasets.toml)
+data:
+  manifest_path: "data/splits/train.csv"
+  batch_size: 32
+  num_workers: 4
+  # audio:
+  #   sample_rate: 16000
+  #   chunk_seconds: 2.0
+
+# Train
+train:
+  epochs: 100
+  lr: 1.0e-3
+  output_dir: "data/checkpoints/jepa"
+  save_every: 10

--- a/agent/data/README.md
+++ b/agent/data/README.md
@@ -1,0 +1,7 @@
+# KmiDi data layout
+
+- **Audio:** `data/audio/` — Raw or processed audio (e.g. train/val splits). See `config/datasets.toml` for paths.
+- **MIDI:** `data/midi/` — MIDI files if the app uses them.
+- **JEPA (optional):** When using libs/jepa for training, add features or manifest paths under `config/datasets.toml` → `[jepa]` and document here.
+
+Do not commit large audio/MIDI; `data/` is ignored at repo root.

--- a/agent/kmidi/__init__.py
+++ b/agent/kmidi/__init__.py
@@ -1,0 +1,1 @@
+"""KmiDi: audio, DAW, and training pipeline tooling."""

--- a/agent/kmidi/agents/__init__.py
+++ b/agent/kmidi/agents/__init__.py
@@ -1,0 +1,12 @@
+"""KmiDi agents: session hub, training runbook, training ops, dataset packager."""
+from kmidi.agents.dataset_packager import DatasetPackagerAgent
+from kmidi.agents.session_hub import SessionHubAgent
+from kmidi.agents.training_ops import TrainingOpsAgent
+from kmidi.agents.training_runbook import TrainingRunbookAgent
+
+__all__ = [
+    "DatasetPackagerAgent",
+    "SessionHubAgent",
+    "TrainingOpsAgent",
+    "TrainingRunbookAgent",
+]

--- a/agent/kmidi/agents/dataset_packager.py
+++ b/agent/kmidi/agents/dataset_packager.py
@@ -1,0 +1,28 @@
+"""Dataset packager agent: build → split → package → validate → sync."""
+from kmidi.tools.dataset_packaging import (
+    BuildTrainingRecordsTool,
+    PackageDatasetTool,
+    SplitDatasetTool,
+    SyncPackageToS3Tool,
+    ValidatePackageTool,
+)
+
+from ai_core.orchestrator import BaseAgentOrchestrator
+
+
+class DatasetPackagerAgent(BaseAgentOrchestrator):
+    """Deterministic dataset packaging from transcript JSONL through S3 sync."""
+
+    def __init__(self):
+        tools = [
+            BuildTrainingRecordsTool(),
+            SplitDatasetTool(),
+            PackageDatasetTool(),
+            ValidatePackageTool(),
+            SyncPackageToS3Tool(),
+        ]
+        system_prompt = """
+        You are the Dataset Packager agent. Build records from transcript JSONL,
+        split deterministically, package, validate, then sync to S3. Use dry-run before write/sync.
+        """
+        super().__init__(tools=tools, system_prompt=system_prompt, max_retries=2)

--- a/agent/kmidi/agents/session_hub.py
+++ b/agent/kmidi/agents/session_hub.py
@@ -1,0 +1,27 @@
+"""Session hub agent: central DAW + voice + events (UnifiedHub-style)."""
+from kmidi.tools.daw import DawGetStateTool, DawPlayTool, DawStopTool
+from kmidi.tools.harmony import HarmonyTool
+from kmidi.tools.intent import IntentTool
+from kmidi.tools.session import IntentParseTool, SessionInterrogateTool
+
+from ai_core.orchestrator import BaseAgentOrchestrator
+
+
+class SessionHubAgent(BaseAgentOrchestrator):
+    """Main KmiDi session agent: DAW control, intent, harmony, session state."""
+
+    def __init__(self):
+        tools = [
+            DawPlayTool(),
+            DawStopTool(),
+            DawGetStateTool(),
+            IntentParseTool(),
+            SessionInterrogateTool(),
+            IntentTool(),
+            HarmonyTool(),
+        ]
+        system_prompt = """
+        You are the KmiDi session agent. Control the DAW (play, stop, get state),
+        parse user intent, interrogate session state, and use harmony when needed.
+        """
+        super().__init__(tools=tools, system_prompt=system_prompt, max_retries=2)

--- a/agent/kmidi/agents/training_ops.py
+++ b/agent/kmidi/agents/training_ops.py
@@ -1,0 +1,33 @@
+"""Training ops agent: preflight, launch AWS, monitor, fetch artifacts."""
+from typing import Any, Dict
+
+from ai_core.interfaces import AgentTool
+from ai_core.orchestrator import BaseAgentOrchestrator
+
+
+class LaunchAwsTrainTool(AgentTool):
+    name = "launch_aws_train"
+    description = "Launch AWS GPU training run (after dry-run and preflight)."
+
+    async def execute(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        return {"status": "success", "dry_run": payload.get("dry_run", False), "run_id": None}
+
+
+class FetchAwsArtifactsTool(AgentTool):
+    name = "fetch_aws_artifacts"
+    description = "Fetch artifacts from completed run (student or break-glass teacher)."
+
+    async def execute(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        return {"status": "success", "run_id": payload.get("run_id"), "output_dir": payload.get("output_dir")}
+
+
+class TrainingOpsAgent(BaseAgentOrchestrator):
+    """Training ops: preflight, launch, monitor, fetch artifacts."""
+
+    def __init__(self):
+        tools = [LaunchAwsTrainTool(), FetchAwsArtifactsTool()]
+        system_prompt = """
+        You are the Training Ops agent. Run preflight, then launch_aws_train (dry-run first),
+        then fetch_aws_artifacts. Preserve runId and output paths.
+        """
+        super().__init__(tools=tools, system_prompt=system_prompt, max_retries=1)

--- a/agent/kmidi/agents/training_runbook.py
+++ b/agent/kmidi/agents/training_runbook.py
@@ -1,0 +1,28 @@
+"""Training runbook agent: transcript → build/split/package/validate/sync → launch → fetch."""
+from kmidi.tools.dataset_packaging import (
+    BuildTrainingRecordsTool,
+    PackageDatasetTool,
+    SplitDatasetTool,
+    SyncPackageToS3Tool,
+    ValidatePackageTool,
+)
+
+from ai_core.orchestrator import BaseAgentOrchestrator
+
+
+class TrainingRunbookAgent(BaseAgentOrchestrator):
+    """End-to-end training runbook: dataset packaging phases then launch/fetch (gate checks)."""
+
+    def __init__(self):
+        tools = [
+            BuildTrainingRecordsTool(),
+            SplitDatasetTool(),
+            PackageDatasetTool(),
+            ValidatePackageTool(),
+            SyncPackageToS3Tool(),
+        ]
+        system_prompt = """
+        You are the Training Runbook agent. Run phases in order: build records, split,
+        package, validate, sync. Do not skip gates; stop on failure.
+        """
+        super().__init__(tools=tools, system_prompt=system_prompt, max_retries=1)

--- a/agent/kmidi/tools/__init__.py
+++ b/agent/kmidi/tools/__init__.py
@@ -1,0 +1,33 @@
+"""KmiDi tools: DAiW (harmony, groove, intent, audio, teaching), DAW, intent/session, dataset packaging."""
+from kmidi.tools.audio_analysis import AudioAnalysisTool
+from kmidi.tools.daw import DawGetStateTool, DawPlayTool, DawStopTool
+from kmidi.tools.dataset_packaging import (
+    BuildTrainingRecordsTool,
+    PackageDatasetTool,
+    SplitDatasetTool,
+    SyncPackageToS3Tool,
+    ValidatePackageTool,
+)
+from kmidi.tools.groove import GrooveTool
+from kmidi.tools.harmony import HarmonyTool
+from kmidi.tools.intent import IntentTool
+from kmidi.tools.session import IntentParseTool, SessionInterrogateTool
+from kmidi.tools.teaching import TeachingTool
+
+__all__ = [
+    "AudioAnalysisTool",
+    "BuildTrainingRecordsTool",
+    "DawGetStateTool",
+    "DawPlayTool",
+    "DawStopTool",
+    "GrooveTool",
+    "HarmonyTool",
+    "IntentParseTool",
+    "IntentTool",
+    "PackageDatasetTool",
+    "SessionInterrogateTool",
+    "SplitDatasetTool",
+    "SyncPackageToS3Tool",
+    "TeachingTool",
+    "ValidatePackageTool",
+]

--- a/agent/kmidi/tools/audio_analysis.py
+++ b/agent/kmidi/tools/audio_analysis.py
@@ -1,0 +1,14 @@
+"""Audio analysis tools (loudness, spectrum, etc.)."""
+from typing import Any, Dict
+
+from ai_core.interfaces import AgentTool
+
+
+class AudioAnalysisTool(AgentTool):
+    name = "audio_analysis"
+    description = "Analyze audio (loudness, spectrum, features)."
+
+    async def execute(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        path = payload.get("path") or payload.get("audio_path")
+        metrics = payload.get("metrics", ["loudness"])
+        return {"status": "success", "path": path, "metrics": metrics, "result": {}}

--- a/agent/kmidi/tools/dataset_packaging.py
+++ b/agent/kmidi/tools/dataset_packaging.py
@@ -1,0 +1,50 @@
+"""Dataset packaging tools: build records, split, package, validate, sync to S3."""
+from typing import Any, Dict
+
+from ai_core.interfaces import AgentTool
+
+
+class BuildTrainingRecordsTool(AgentTool):
+    name = "build_training_records"
+    description = "Build training records from transcript JSONL (intent_router, axis_proposer)."
+
+    async def execute(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        path = payload.get("transcript_jsonl") or payload.get("path", "")
+        return {"status": "success", "path": path, "outputs": []}
+
+
+class SplitDatasetTool(AgentTool):
+    name = "split_dataset"
+    description = "Split records deterministically by sessionId (train/val/test)."
+
+    async def execute(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        return {"status": "success", "splits": {}}
+
+
+class PackageDatasetTool(AgentTool):
+    name = "package_dataset"
+    description = "Package dataset shards and manifests for a given package-id."
+
+    async def execute(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        package_id = payload.get("package_id", "")
+        dry_run = payload.get("dry_run", False)
+        return {"status": "success", "package_id": package_id, "dry_run": dry_run}
+
+
+class ValidatePackageTool(AgentTool):
+    name = "validate_package"
+    description = "Validate package integrity (schema, checksum, shard counts)."
+
+    async def execute(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        package_dir = payload.get("package_dir") or payload.get("path", "")
+        return {"status": "success", "package_dir": package_dir, "valid": True}
+
+
+class SyncPackageToS3Tool(AgentTool):
+    name = "sync_package_to_s3"
+    description = "Sync package directory to S3 (incremental by SHA256)."
+
+    async def execute(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        package_dir = payload.get("package_dir") or payload.get("path", "")
+        dry_run = payload.get("dry_run", False)
+        return {"status": "success", "package_dir": package_dir, "dry_run": dry_run}

--- a/agent/kmidi/tools/daw.py
+++ b/agent/kmidi/tools/daw.py
@@ -1,0 +1,28 @@
+"""DAW transport and state tools (play, stop, get state)."""
+from typing import Any, Dict
+
+from ai_core.interfaces import AgentTool
+
+
+class DawPlayTool(AgentTool):
+    name = "daw_play"
+    description = "Start DAW playback."
+
+    async def execute(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        return {"status": "success", "action": "play"}
+
+
+class DawStopTool(AgentTool):
+    name = "daw_stop"
+    description = "Stop DAW playback."
+
+    async def execute(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        return {"status": "success", "action": "stop"}
+
+
+class DawGetStateTool(AgentTool):
+    name = "daw_get_state"
+    description = "Get current DAW state (transport, tempo, etc.)."
+
+    async def execute(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        return {"status": "success", "state": {"playing": False, "tempo": 120}}

--- a/agent/kmidi/tools/groove.py
+++ b/agent/kmidi/tools/groove.py
@@ -1,0 +1,13 @@
+"""Groove tools for rhythm and timing."""
+from typing import Any, Dict
+
+from ai_core.interfaces import AgentTool
+
+
+class GrooveTool(AgentTool):
+    name = "groove"
+    description = "Analyze or apply groove (rhythm, swing, timing)."
+
+    async def execute(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        action = payload.get("action", "analyze")
+        return {"status": "success", "action": action, "result": {}}

--- a/agent/kmidi/tools/harmony.py
+++ b/agent/kmidi/tools/harmony.py
@@ -1,0 +1,14 @@
+"""Harmony tools for chord/key analysis and suggestions."""
+from typing import Any, Dict
+
+from ai_core.interfaces import AgentTool
+
+
+class HarmonyTool(AgentTool):
+    name = "harmony"
+    description = "Analyze or suggest harmony (chords, key, progressions)."
+
+    async def execute(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        action = payload.get("action", "analyze")
+        # Stub: in production call DAiW MCP harmony tools.
+        return {"status": "success", "action": action, "result": {}}

--- a/agent/kmidi/tools/intent.py
+++ b/agent/kmidi/tools/intent.py
@@ -1,0 +1,13 @@
+"""Intent tools for parsing user music production intent."""
+from typing import Any, Dict
+
+from ai_core.interfaces import AgentTool
+
+
+class IntentTool(AgentTool):
+    name = "intent"
+    description = "Parse or resolve user intent (e.g. 'make it darker', 'add a fill')."
+
+    async def execute(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        text = payload.get("text") or payload.get("query", "")
+        return {"status": "success", "intent": {}, "text": text[:200]}

--- a/agent/kmidi/tools/session.py
+++ b/agent/kmidi/tools/session.py
@@ -1,0 +1,22 @@
+"""Session and intent parsing tools."""
+from typing import Any, Dict
+
+from ai_core.interfaces import AgentTool
+
+
+class IntentParseTool(AgentTool):
+    name = "intent_parse"
+    description = "Parse user utterance into structured intent (goal, parameters)."
+
+    async def execute(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        utterance = payload.get("utterance") or payload.get("text", "")
+        return {"status": "success", "intent": {}, "utterance": utterance[:200]}
+
+
+class SessionInterrogateTool(AgentTool):
+    name = "session_interrogate"
+    description = "Query current session state (tracks, selection, context)."
+
+    async def execute(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        query = payload.get("query", "state")
+        return {"status": "success", "query": query, "session": {}}

--- a/agent/kmidi/tools/teaching.py
+++ b/agent/kmidi/tools/teaching.py
@@ -1,0 +1,13 @@
+"""Teaching tools for learning/coaching in music production."""
+from typing import Any, Dict
+
+from ai_core.interfaces import AgentTool
+
+
+class TeachingTool(AgentTool):
+    name = "teaching"
+    description = "Get teaching/coaching suggestions for a concept or skill."
+
+    async def execute(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        topic = payload.get("topic") or payload.get("concept", "")
+        return {"status": "success", "topic": topic[:200], "suggestions": []}

--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["hatchling>=1.25.0"]
+build-backend = "hatchling.build"
+
+[project]
+name = "kmidi"
+version = "0.1.0"
+description = "Audio and DAW tooling (KmiDi + iDAW)"
+requires-python = ">=3.11"
+dependencies = [
+    "langgraph",   # required by vendored ai_core
+]
+
+# ai_core is vendored in-tree (./ai_core) — self-contained, no workspace dependency.

--- a/agent/tests/test_placeholder.py
+++ b/agent/tests/test_placeholder.py
@@ -1,0 +1,2 @@
+def test_kmidi_placeholder() -> None:
+    assert True


### PR DESCRIPTION
Migrated from the retired workspace-scaffold UV monorepo (apps/kmidi).
ai_core vendored in-tree; self-contained pyproject. Other working-tree
changes (.gradle, .cursor) intentionally not staged.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Greenfield scaffold with stub implementations and no changes to existing production paths; AWS/S3 tool names are placeholders only until wired.
> 
> **Overview**
> Introduces a **self-contained `agent/` package** migrated from the retired `apps/kmidi` UV monorepo layout, with **`ai_core` vendored in-tree** and a minimal **`pyproject.toml`** that depends only on `langgraph`.
> 
> The new stack wires **LangGraph-based orchestration** (`BaseAgentOrchestrator`, `AgentTool`) to four **KmiDi agents**—session hub, dataset packager, training runbook, and training ops—backed by **stub tools** for DAW transport, session/intent, harmony/groove/teaching, audio analysis, dataset packaging (through S3 sync), and AWS train launch/fetch. **Config and docs** land as stubs: `config/datasets.toml`, `config/training.yaml`, `data/README`, plus roadmap/completion/workspace READMEs and a placeholder pytest.
> 
> **Not in this PR:** `kmidi/audio.py`, `midi.py`, `main.py`, or real tool/agent behavior—those remain future work per the checklists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2a5d6c29991ceac01641d72e675e8f18ca7004a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->