### PR TITLE
feat: port Universal Music Input (NLP text-to-intent + dual-pane UI) from archive

### DIFF
--- a/music_brain/api.py
+++ b/music_brain/api.py
@@ -17,7 +17,7 @@ try:
     from fastapi import APIRouter, Body, FastAPI, HTTPException
     from fastapi.middleware.cors import CORSMiddleware
     from fastapi.responses import FileResponse
-    from pydantic import BaseModel
+    from pydantic import BaseModel, Field
 
     FASTAPI_AVAILABLE = True
 except ImportError:  # pragma: no cover - optional dependency
@@ -1703,6 +1703,30 @@ if FASTAPI_AVAILABLE:
             ),
             "session_id": request.session_id,
         }
+
+    class ParseTextRequest(BaseModel):
+        text: str = Field(..., max_length=4096)
+        locale: Optional[str] = "en"
+        user_id: Optional[str] = None
+
+    @app.post(
+        "/parse-text",
+        summary="Interpret Text",
+        description="Convert natural language into probabilistic musical parameter "
+        "distributions — context clusters, activated taxonomy nodes, and "
+        "confidence levels, not fixed values.",
+    )
+    @api_error_handler(log_message="parse-text failed", detail=_HTTP_500_DETAIL)
+    async def parse_text(request: ParseTextRequest):
+        """Interpret free text into probabilistic musical parameter distributions."""
+        from music_brain.nlp.text_to_intent_service import TextToIntentService
+
+        service = TextToIntentService()
+        return service.parse(
+            text=request.text,
+            locale=request.locale or "en",
+            user_id=request.user_id,
+        )
 
     @app.post(
         "/lyrics",

--- a/music_brain/nlp/__init__.py
+++ b/music_brain/nlp/__init__.py
@@ -1,0 +1,6 @@
+"""
+Natural Language Processing module for KmiDi Universal Music Input.
+
+Converts free-text descriptions into probabilistic musical parameter
+distributions and context cluster activations.
+"""

--- a/music_brain/nlp/keyword_extractor.py
+++ b/music_brain/nlp/keyword_extractor.py
@@ -1,0 +1,349 @@
+"""
+Musical Keyword Extractor
+
+Extracts musical keywords from free-text descriptions. Unlike the emotion
+parser (which handles feelings), this extracts concrete musical terms:
+instruments, techniques, tempo/density modifiers, genre markers.
+
+These keywords feed into context cluster matching — "overdrive" alone
+doesn't set a parameter, but "overdrive + fast + guitar" activates the
+metal-shred cluster which shifts everything.
+"""
+
+import re
+from dataclasses import dataclass, field
+from typing import Dict, List, Set, Tuple
+
+
+@dataclass
+class ExtractedKeywords:
+    """Result of keyword extraction from text."""
+
+    instruments: List[str] = field(default_factory=list)
+    techniques: List[str] = field(default_factory=list)
+    tempo_words: List[str] = field(default_factory=list)
+    density_words: List[str] = field(default_factory=list)
+    genre_markers: List[str] = field(default_factory=list)
+    feel_words: List[str] = field(default_factory=list)
+    mode_words: List[str] = field(default_factory=list)
+    structure_words: List[str] = field(default_factory=list)
+    dynamic_words: List[str] = field(default_factory=list)
+    all_matched: List[str] = field(default_factory=list)
+    taxonomy_hints: List[str] = field(default_factory=list)
+
+
+# Word → (category, canonical_form, taxonomy_node_id)
+KEYWORD_MAP: Dict[str, Tuple[str, str, str]] = {}
+
+_KEYWORD_GROUPS: Dict[str, Dict[str, str]] = {
+    # instrument words → taxonomy node ID
+    "instruments": {
+        "guitar": "timbre.instruments.electric-guitar",
+        "electric guitar": "timbre.instruments.electric-guitar",
+        "acoustic guitar": "timbre.instruments.acoustic-guitar",
+        "acoustic": "timbre.instruments.acoustic-guitar",
+        "bass": "timbre.instruments.bass-guitar",
+        "bass guitar": "timbre.instruments.bass-guitar",
+        "upright bass": "timbre.instruments.upright-bass",
+        "piano": "timbre.instruments.piano",
+        "keys": "timbre.instruments.piano",
+        "keyboard": "timbre.instruments.piano",
+        "electric piano": "timbre.instruments.electric-piano",
+        "rhodes": "timbre.instruments.electric-piano",
+        "wurlitzer": "timbre.instruments.electric-piano",
+        "organ": "timbre.instruments.organ",
+        "synth": "timbre.instruments.synth-lead",
+        "synthesizer": "timbre.instruments.synth-lead",
+        "synth lead": "timbre.instruments.synth-lead",
+        "synth pad": "timbre.instruments.synth-pad",
+        "pad": "timbre.instruments.synth-pad",
+        "synth bass": "timbre.instruments.synth-bass",
+        "strings": "timbre.instruments.strings",
+        "violin": "timbre.instruments.violin",
+        "cello": "timbre.instruments.cello",
+        "brass": "timbre.instruments.brass",
+        "trumpet": "timbre.instruments.trumpet",
+        "horn": "timbre.instruments.brass",
+        "sax": "timbre.instruments.sax",
+        "saxophone": "timbre.instruments.sax",
+        "flute": "timbre.instruments.flute",
+        "woodwinds": "timbre.instruments.woodwinds",
+        "drums": "timbre.instruments.drums",
+        "percussion": "timbre.instruments.percussion",
+        "choir": "timbre.instruments.choir",
+        "vocals": "timbre.instruments.choir",
+        "808": "timbre.instruments.808",
+        "harp": "timbre.instruments.harp",
+        "marimba": "timbre.instruments.marimba",
+        "vibraphone": "timbre.instruments.vibraphone",
+        "vibes": "timbre.instruments.vibraphone",
+        "fiddle": "timbre.instruments.violin",
+        "pedal steel": "timbre.instruments.electric-guitar",
+    },
+    "techniques": {
+        "overdrive": "timbre.effects.overdrive",
+        "distortion": "timbre.effects.distortion",
+        "distorted": "timbre.effects.distortion",
+        "clean": "timbre.effects.clean",
+        "reverb": "timbre.effects.reverb",
+        "delay": "timbre.effects.delay",
+        "echo": "timbre.effects.delay",
+        "chorus": "timbre.effects.chorus-effect",
+        "flanger": "timbre.effects.flanger",
+        "phaser": "timbre.effects.phaser",
+        "wah": "timbre.effects.wah",
+        "compression": "timbre.effects.compression",
+        "compressed": "timbre.effects.compression",
+        "bitcrushed": "timbre.effects.bitcrusher",
+        "lo-fi": "timbre.effects.lo-fi",
+        "lofi": "timbre.effects.lo-fi",
+        "staccato": "articulation.staccato",
+        "legato": "articulation.legato",
+        "portamento": "articulation.portamento",
+        "glissando": "articulation.glissando",
+        "vibrato": "articulation.vibrato",
+        "tremolo": "articulation.tremolo",
+        "pizzicato": "articulation.pizzicato",
+        "arco": "articulation.arco",
+        "muted": "articulation.muted",
+        "palm mute": "articulation.palm-mute",
+        "palm-muted": "articulation.palm-mute",
+        "hammer-on": "articulation.hammer-on",
+        "pull-off": "articulation.pull-off",
+        "tapping": "articulation.tapping",
+        "fingerpicking": "articulation.fingerpicking",
+        "fingerpicked": "articulation.fingerpicking",
+        "strumming": "articulation.strumming",
+        "strummed": "articulation.strumming",
+        "slap": "articulation.slap",
+        "slap bass": "articulation.slap",
+        "harmonics": "articulation.harmonics",
+        "bend": "articulation.bend",
+        "bending": "articulation.bend",
+        "slide": "articulation.slide",
+        "power chords": "harmony.chords.power-chord",
+        "power chord": "harmony.chords.power-chord",
+        "arpeggiated": "melody.contour.wave",
+        "arpeggio": "melody.contour.wave",
+    },
+    "tempo_words": {
+        "fast": "rhythm.density.dense",
+        "quick": "rhythm.density.dense",
+        "rapid": "rhythm.density.dense",
+        "driving": "rhythm.groove-feel.straight-driving",
+        "rushing": "rhythm.groove-feel.straight-driving",
+        "uptempo": "rhythm.density.dense",
+        "slow": "rhythm.density.sparse",
+        "laid-back": "rhythm.groove-feel.laid-back",
+        "laid back": "rhythm.groove-feel.laid-back",
+        "crawling": "rhythm.density.sparse",
+        "plodding": "rhythm.density.sparse",
+        "moderate": "rhythm.density.medium",
+        "mid-tempo": "rhythm.density.medium",
+        "medium": "rhythm.density.medium",
+        "breakneck": "rhythm.density.dense",
+        "blistering": "rhythm.density.dense",
+        "relaxed": "rhythm.groove-feel.laid-back",
+        "chill": "rhythm.groove-feel.laid-back",
+        "gentle": "rhythm.density.sparse",
+    },
+    "density_words": {
+        "busy": "rhythm.density.dense",
+        "sparse": "rhythm.density.sparse",
+        "thick": "texture.density.thick",
+        "thin": "texture.density.thin",
+        "minimal": "texture.density.monophonic",
+        "minimalist": "texture.density.monophonic",
+        "dense": "rhythm.density.dense",
+        "lush": "texture.density.thick",
+        "full": "texture.density.thick",
+        "empty": "texture.density.thin",
+        "spacious": "texture.space.hall",
+        "massive": "texture.density.massive",
+        "wall of sound": "texture.density.massive",
+        "stripped": "texture.density.thin",
+        "bare": "texture.density.monophonic",
+        "layered": "texture.density.thick",
+    },
+    "genre_markers": {
+        "bluesy": "harmony.scales.blues",
+        "blues": "harmony.scales.blues",
+        "jazzy": "harmony.scales.dorian",
+        "jazz": "harmony.scales.dorian",
+        "metal": "harmony.scales.phrygian",
+        "punk": "harmony.scales.minor",
+        "ambient": "timbre.instruments.synth-pad",
+        "funky": "rhythm.groove-feel.syncopated",
+        "funk": "rhythm.groove-feel.syncopated",
+        "classical": "timbre.instruments.strings",
+        "orchestral": "timbre.instruments.strings",
+        "cinematic": "timbre.instruments.strings",
+        "electronic": "timbre.instruments.synth-lead",
+        "edm": "timbre.instruments.synth-lead",
+        "house": "rhythm.patterns.four-on-floor",
+        "techno": "rhythm.patterns.four-on-floor",
+        "hip-hop": "rhythm.patterns.boom-bap",
+        "hip hop": "rhythm.patterns.boom-bap",
+        "trap": "timbre.instruments.808",
+        "r&b": "rhythm.groove-feel.laid-back",
+        "rnb": "rhythm.groove-feel.laid-back",
+        "soul": "rhythm.groove-feel.laid-back",
+        "reggae": "rhythm.syncopation.offbeat",
+        "country": "timbre.instruments.acoustic-guitar",
+        "folk": "timbre.instruments.acoustic-guitar",
+        "indie": "timbre.instruments.acoustic-guitar",
+        "pop": "harmony.scales.major",
+        "rock": "timbre.effects.overdrive",
+        "grunge": "timbre.effects.distortion",
+        "prog": "rhythm.time-signatures.7-8",
+        "progressive": "rhythm.time-signatures.7-8",
+        "latin": "rhythm.patterns.clave",
+        "salsa": "rhythm.patterns.clave",
+        "bossa nova": "rhythm.swing.light-swing",
+        "bossa": "rhythm.swing.light-swing",
+        "gospel": "timbre.instruments.organ",
+        "synthwave": "timbre.instruments.synth-lead",
+        "retrowave": "timbre.instruments.synth-lead",
+        "lo-fi hip hop": "timbre.effects.lo-fi",
+        "boom bap": "rhythm.patterns.boom-bap",
+        "drill": "timbre.instruments.808",
+        "dnb": "rhythm.density.dense",
+        "drum and bass": "rhythm.density.dense",
+        "dubstep": "timbre.instruments.synth-bass",
+        "neo-soul": "rhythm.groove-feel.laid-back",
+    },
+    "feel_words": {
+        "groovy": "rhythm.groove-feel.syncopated",
+        "tight": "rhythm.groove-feel.mechanical",
+        "loose": "rhythm.groove-feel.organic",
+        "swinging": "rhythm.swing.heavy-swing",
+        "swing": "rhythm.swing.heavy-swing",
+        "swung": "rhythm.swing.heavy-swing",
+        "straight": "rhythm.swing.straight",
+        "mechanical": "rhythm.groove-feel.mechanical",
+        "robotic": "rhythm.groove-feel.mechanical",
+        "organic": "rhythm.groove-feel.organic",
+        "human": "rhythm.groove-feel.organic",
+        "natural": "rhythm.groove-feel.organic",
+        "breathing": "rhythm.groove-feel.organic",
+        "syncopated": "rhythm.syncopation.heavy",
+        "offbeat": "rhythm.syncopation.offbeat",
+        "free": "rhythm.groove-feel.rubato",
+        "rubato": "rhythm.groove-feel.rubato",
+        "pushing": "rhythm.groove-feel.push-pull",
+        "pulling": "rhythm.groove-feel.push-pull",
+        "shuffle": "rhythm.patterns.shuffle",
+        "shuffling": "rhythm.patterns.shuffle",
+        "bouncy": "rhythm.swing.light-swing",
+    },
+    "mode_words": {
+        "dorian": "harmony.scales.dorian",
+        "phrygian": "harmony.scales.phrygian",
+        "lydian": "harmony.scales.lydian",
+        "mixolydian": "harmony.scales.mixolydian",
+        "aeolian": "harmony.scales.minor",
+        "locrian": "harmony.scales.locrian",
+        "major": "harmony.scales.major",
+        "minor": "harmony.scales.minor",
+        "pentatonic": "harmony.scales.pentatonic-minor",
+        "minor pentatonic": "harmony.scales.pentatonic-minor",
+        "major pentatonic": "harmony.scales.pentatonic-major",
+        "blues scale": "harmony.scales.blues",
+        "chromatic": "harmony.scales.chromatic",
+        "whole tone": "harmony.scales.whole-tone",
+        "harmonic minor": "harmony.scales.harmonic-minor",
+        "melodic minor": "harmony.scales.melodic-minor",
+        "diminished": "harmony.scales.diminished",
+    },
+    "dynamic_words": {
+        "quiet": "dynamics.levels.p",
+        "soft": "dynamics.levels.pp",
+        "gentle": "dynamics.levels.pp",
+        "whisper": "dynamics.levels.pp",
+        "delicate": "dynamics.levels.pp",
+        "moderate volume": "dynamics.levels.mf",
+        "loud": "dynamics.levels.f",
+        "powerful": "dynamics.levels.ff",
+        "aggressive": "dynamics.levels.ff",
+        "intense": "dynamics.levels.ff",
+        "explosive": "dynamics.levels.ff",
+        "crescendo": "dynamics.changes.crescendo",
+        "building": "dynamics.changes.crescendo",
+        "fading": "dynamics.changes.decrescendo",
+        "dying": "dynamics.changes.decrescendo",
+        "diminishing": "dynamics.changes.decrescendo",
+        "swelling": "dynamics.changes.swell",
+    },
+    "structure_words": {
+        "intro": "structure.sections.intro",
+        "verse": "structure.sections.verse",
+        "chorus": "structure.sections.chorus",
+        "bridge": "structure.sections.bridge",
+        "outro": "structure.sections.outro",
+        "build": "structure.sections.build",
+        "buildup": "structure.sections.build",
+        "drop": "structure.sections.drop",
+        "breakdown": "structure.sections.breakdown",
+        "solo": "structure.sections.solo",
+    },
+}
+
+# Build flat lookup: lowercase word → (category, canonical_word, taxonomy_id)
+for _cat, _words in _KEYWORD_GROUPS.items():
+    for _word, _tax_id in _words.items():
+        KEYWORD_MAP[_word.lower()] = (_cat, _word, _tax_id)
+
+
+class KeywordExtractor:
+    """
+    Extract musical keywords from free-text descriptions.
+
+    Scans text for known musical terms (instruments, techniques, genres, etc.)
+    and returns structured results with taxonomy node ID hints.
+    """
+
+    def __init__(self):
+        # Sort keywords by length descending so multi-word matches take priority
+        self._sorted_keywords = sorted(KEYWORD_MAP.keys(), key=len, reverse=True)
+
+    def extract(self, text: str) -> ExtractedKeywords:
+        """Extract all musical keywords from text."""
+        result = ExtractedKeywords()
+        lower_text = f" {text.lower()} "
+        matched_spans: Set[Tuple[int, int]] = set()
+
+        for keyword in self._sorted_keywords:
+            # Search for keyword as a whole word
+            pattern = r"\b" + re.escape(keyword) + r"\b"
+            for match in re.finditer(pattern, lower_text):
+                start, end = match.start(), match.end()
+                # Skip if this span overlaps with an already-matched span
+                if any(not (end <= ms or start >= me) for ms, me in matched_spans):
+                    continue
+
+                matched_spans.add((start, end))
+                category, canonical, taxonomy_id = KEYWORD_MAP[keyword]
+
+                result.all_matched.append(canonical)
+                result.taxonomy_hints.append(taxonomy_id)
+
+                if category == "instruments":
+                    result.instruments.append(canonical)
+                elif category == "techniques":
+                    result.techniques.append(canonical)
+                elif category == "tempo_words":
+                    result.tempo_words.append(canonical)
+                elif category == "density_words":
+                    result.density_words.append(canonical)
+                elif category == "genre_markers":
+                    result.genre_markers.append(canonical)
+                elif category == "feel_words":
+                    result.feel_words.append(canonical)
+                elif category == "mode_words":
+                    result.mode_words.append(canonical)
+                elif category == "dynamic_words":
+                    result.dynamic_words.append(canonical)
+                elif category == "structure_words":
+                    result.structure_words.append(canonical)
+
+        return result

--- a/music_brain/nlp/text_to_intent_service.py
+++ b/music_brain/nlp/text_to_intent_service.py
@@ -1,0 +1,729 @@
+"""
+Text-to-Intent Service
+
+Wraps TextEmotionParser, KeywordExtractor, and emotional_mapping to convert
+free-text descriptions into probabilistic musical parameter distributions.
+
+Returns distributions (not fixed values) so the frontend can sample different
+results from the same input, controlled by the interpretive slider.
+"""
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Any
+
+from music_brain.nlp.keyword_extractor import KeywordExtractor, ExtractedKeywords
+
+# Lazy imports for optional dependencies
+_emotion_parser = None
+_emotional_mapping = None
+
+
+def _get_emotion_parser():
+    global _emotion_parser
+    if _emotion_parser is None:
+        try:
+            from music_brain.emotion.text_emotion_parser import TextEmotionParser
+
+            _emotion_parser = TextEmotionParser()
+        except ImportError:
+            _emotion_parser = None
+    return _emotion_parser
+
+
+def _get_emotional_mapping():
+    global _emotional_mapping
+    if _emotional_mapping is None:
+        try:
+            from music_brain.data_utils import emotional_mapping
+
+            _emotional_mapping = emotional_mapping
+        except ImportError:
+            _emotional_mapping = None
+    return _emotional_mapping
+
+
+@dataclass
+class ParamDistribution:
+    """A probability distribution over possible values."""
+
+    type: str  # 'gaussian', 'discrete', 'range'
+    center: Optional[float] = None
+    spread: Optional[float] = None
+    weights: Optional[Dict[str, float]] = None
+    min: Optional[float] = None
+    max: Optional[float] = None
+    bias: Optional[float] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {"type": self.type}
+        if self.center is not None:
+            d["center"] = self.center
+        if self.spread is not None:
+            d["spread"] = self.spread
+        if self.weights is not None:
+            d["weights"] = self.weights
+        if self.min is not None:
+            d["min"] = self.min
+        if self.max is not None:
+            d["max"] = self.max
+        if self.bias is not None:
+            d["bias"] = self.bias
+        return d
+
+
+@dataclass
+class ClusterActivation:
+    """A detected context cluster with confidence."""
+
+    id: str
+    confidence: float
+    label: str
+
+
+@dataclass
+class InterpretationResult:
+    """Full result of text-to-intent interpretation."""
+
+    param_distributions: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    activated_clusters: List[Dict[str, Any]] = field(default_factory=list)
+    activated_taxonomy_ids: List[str] = field(default_factory=list)
+    detected_keywords: List[str] = field(default_factory=list)
+    confidence: float = 0.5
+
+
+# Context cluster definitions (mirroring frontend contextClusters.ts)
+# These define what combinations of keywords activate which genre/style
+CLUSTER_TRIGGERS: Dict[str, Dict[str, Any]] = {
+    "metal-shred": {
+        "label": "Metal/Prog Shred",
+        "keywords": {
+            "fast",
+            "guitar",
+            "overdrive",
+            "distortion",
+            "distorted",
+            "metal",
+            "shred",
+            "heavy",
+            "aggressive",
+            "blistering",
+        },
+        "modes": {"dorian", "phrygian", "minor", "harmonic minor", "locrian"},
+        "min_match": 2,
+        "overrides": {
+            "tempo": ParamDistribution("gaussian", center=160, spread=15),
+            "density": ParamDistribution("range", min=0.8, max=1.0, bias=0.9),
+            "dynamics": ParamDistribution("discrete", weights={"f": 0.4, "ff": 0.6}),
+            "timing_feel": ParamDistribution("discrete", weights={"on": 0.6, "ahead": 0.4}),
+            "groove_strength": ParamDistribution("range", min=0.5, max=0.8, bias=0.6),
+        },
+    },
+    "blues-slow": {
+        "label": "Slow Blues",
+        "keywords": {
+            "slow",
+            "blues",
+            "bluesy",
+            "clean",
+            "pentatonic",
+            "laid-back",
+            "laid back",
+            "soulful",
+            "mellow",
+        },
+        "modes": {
+            "pentatonic",
+            "minor pentatonic",
+            "blues scale",
+            "minor",
+            "mixolydian",
+            "dorian",
+        },
+        "min_match": 2,
+        "overrides": {
+            "tempo": ParamDistribution("gaussian", center=72, spread=8),
+            "density": ParamDistribution("discrete", weights={"sparse": 0.6, "medium": 0.4}),
+            "dynamics": ParamDistribution("discrete", weights={"mp": 0.5, "mf": 0.3, "p": 0.2}),
+            "timing_feel": ParamDistribution("discrete", weights={"behind": 0.8, "on": 0.2}),
+            "space_probability": ParamDistribution("range", min=0.2, max=0.4, bias=0.3),
+        },
+    },
+    "jazz-modal": {
+        "label": "Modal Jazz",
+        "keywords": {
+            "jazz",
+            "jazzy",
+            "walking bass",
+            "swing",
+            "swinging",
+            "cool",
+            "modal",
+            "sax",
+            "saxophone",
+            "piano",
+        },
+        "modes": {"dorian", "lydian", "mixolydian", "minor"},
+        "min_match": 2,
+        "overrides": {
+            "tempo": ParamDistribution("gaussian", center=130, spread=20),
+            "density": ParamDistribution(
+                "discrete", weights={"medium": 0.5, "dense": 0.3, "sparse": 0.2}
+            ),
+            "swing": ParamDistribution("range", min=0.5, max=0.8, bias=0.7),
+            "harmonic_rhythm": ParamDistribution(
+                "discrete", weights={"fast": 0.5, "medium": 0.4, "slow": 0.1}
+            ),
+        },
+    },
+    "ambient-pad": {
+        "label": "Ambient Pad",
+        "keywords": {
+            "ambient",
+            "pad",
+            "synth pad",
+            "reverb",
+            "atmospheric",
+            "ethereal",
+            "dreamy",
+            "floating",
+            "spacious",
+            "drone",
+        },
+        "modes": {"lydian", "major", "mixolydian", "whole tone"},
+        "min_match": 2,
+        "overrides": {
+            "tempo": ParamDistribution("gaussian", center=65, spread=10),
+            "density": ParamDistribution("discrete", weights={"sparse": 0.7, "medium": 0.3}),
+            "dynamics": ParamDistribution("discrete", weights={"pp": 0.4, "p": 0.4, "mp": 0.2}),
+            "space_probability": ParamDistribution("range", min=0.3, max=0.6, bias=0.4),
+        },
+    },
+    "funk-groove": {
+        "label": "Funk Groove",
+        "keywords": {
+            "funk",
+            "funky",
+            "groovy",
+            "groove",
+            "syncopated",
+            "slap",
+            "slap bass",
+            "tight",
+            "bass",
+        },
+        "modes": {"dorian", "mixolydian", "minor", "pentatonic"},
+        "min_match": 2,
+        "overrides": {
+            "tempo": ParamDistribution("gaussian", center=105, spread=10),
+            "groove_strength": ParamDistribution("range", min=0.8, max=1.0, bias=0.9),
+            "timing_feel": ParamDistribution("discrete", weights={"ahead": 0.5, "on": 0.5}),
+            "density": ParamDistribution("discrete", weights={"medium": 0.6, "dense": 0.4}),
+        },
+    },
+    "pop-upbeat": {
+        "label": "Upbeat Pop",
+        "keywords": {
+            "pop",
+            "upbeat",
+            "catchy",
+            "bright",
+            "happy",
+            "energetic",
+            "cheerful",
+            "bouncy",
+        },
+        "modes": {"major", "lydian", "mixolydian"},
+        "min_match": 2,
+        "overrides": {
+            "tempo": ParamDistribution("gaussian", center=118, spread=10),
+            "density": ParamDistribution("discrete", weights={"medium": 0.7, "dense": 0.3}),
+            "dynamics": ParamDistribution("discrete", weights={"mf": 0.5, "f": 0.3, "mp": 0.2}),
+        },
+    },
+    "lo-fi-chill": {
+        "label": "Lo-fi Chill",
+        "keywords": {
+            "lo-fi",
+            "lofi",
+            "chill",
+            "vinyl",
+            "tape",
+            "warm",
+            "cozy",
+            "study",
+            "relax",
+            "mellow",
+        },
+        "modes": {"dorian", "mixolydian", "minor", "pentatonic"},
+        "min_match": 2,
+        "overrides": {
+            "tempo": ParamDistribution("gaussian", center=78, spread=6),
+            "timing_feel": ParamDistribution("discrete", weights={"behind": 0.8, "on": 0.2}),
+            "density": ParamDistribution("discrete", weights={"sparse": 0.6, "medium": 0.4}),
+            "space_probability": ParamDistribution("range", min=0.15, max=0.3, bias=0.25),
+        },
+    },
+    "edm-drop": {
+        "label": "EDM Drop",
+        "keywords": {
+            "edm",
+            "drop",
+            "build",
+            "buildup",
+            "electronic",
+            "synth",
+            "bass drop",
+            "heavy",
+            "massive",
+        },
+        "modes": {"minor", "phrygian", "aeolian"},
+        "min_match": 2,
+        "overrides": {
+            "tempo": ParamDistribution("gaussian", center=128, spread=5),
+            "density": ParamDistribution("range", min=0.7, max=1.0, bias=0.9),
+            "dynamics": ParamDistribution("discrete", weights={"ff": 0.7, "f": 0.3}),
+        },
+    },
+    "hip-hop-boom-bap": {
+        "label": "Boom Bap",
+        "keywords": {
+            "hip-hop",
+            "hip hop",
+            "boom bap",
+            "rap",
+            "oldschool",
+            "drums",
+            "sample",
+            "vinyl",
+        },
+        "modes": {"minor", "dorian", "pentatonic"},
+        "min_match": 2,
+        "overrides": {
+            "tempo": ParamDistribution("gaussian", center=90, spread=5),
+            "groove_strength": ParamDistribution("range", min=0.7, max=0.9, bias=0.8),
+            "timing_feel": ParamDistribution("discrete", weights={"behind": 0.6, "on": 0.4}),
+        },
+    },
+    "cinematic-epic": {
+        "label": "Cinematic Epic",
+        "keywords": {
+            "cinematic",
+            "epic",
+            "orchestral",
+            "film",
+            "movie",
+            "dramatic",
+            "sweeping",
+            "massive",
+            "strings",
+            "brass",
+            "choir",
+        },
+        "modes": {"minor", "aeolian", "dorian", "phrygian"},
+        "min_match": 2,
+        "overrides": {
+            "tempo": ParamDistribution("gaussian", center=90, spread=15),
+            "density": ParamDistribution("range", min=0.5, max=1.0, bias=0.8),
+            "dynamics": ParamDistribution(
+                "discrete", weights={"ff": 0.3, "f": 0.3, "pp": 0.2, "p": 0.2}
+            ),
+        },
+    },
+    "punk-rock": {
+        "label": "Punk Rock",
+        "keywords": {
+            "punk",
+            "fast",
+            "distortion",
+            "distorted",
+            "aggressive",
+            "raw",
+            "loud",
+            "power chords",
+            "angry",
+        },
+        "modes": {"minor", "phrygian"},
+        "min_match": 2,
+        "overrides": {
+            "tempo": ParamDistribution("gaussian", center=175, spread=15),
+            "density": ParamDistribution("range", min=0.7, max=1.0, bias=0.85),
+            "dynamics": ParamDistribution("discrete", weights={"ff": 0.7, "f": 0.3}),
+        },
+    },
+    "reggae": {
+        "label": "Reggae",
+        "keywords": {"reggae", "offbeat", "dub", "ska", "island", "bass", "laid-back"},
+        "modes": {"minor", "dorian", "mixolydian"},
+        "min_match": 2,
+        "overrides": {
+            "tempo": ParamDistribution("gaussian", center=80, spread=5),
+            "timing_feel": ParamDistribution("discrete", weights={"behind": 0.7, "on": 0.3}),
+            "groove_strength": ParamDistribution("range", min=0.7, max=0.9, bias=0.8),
+        },
+    },
+    "post-rock": {
+        "label": "Post-Rock",
+        "keywords": {
+            "post-rock",
+            "atmospheric",
+            "reverb",
+            "crescendo",
+            "building",
+            "guitar",
+            "delay",
+            "ethereal",
+            "wall of sound",
+        },
+        "modes": {"minor", "aeolian", "dorian"},
+        "min_match": 2,
+        "overrides": {
+            "tempo": ParamDistribution("gaussian", center=90, spread=10),
+            "dynamics": ParamDistribution(
+                "discrete", weights={"pp": 0.3, "p": 0.2, "ff": 0.3, "f": 0.2}
+            ),
+            "space_probability": ParamDistribution("range", min=0.1, max=0.35, bias=0.2),
+        },
+    },
+    "synthwave-retro": {
+        "label": "Synthwave/Retrowave",
+        "keywords": {
+            "synthwave",
+            "retrowave",
+            "80s",
+            "neon",
+            "retro",
+            "synth",
+            "arpeggiated",
+            "arpeggio",
+            "driving",
+        },
+        "modes": {"minor", "dorian", "phrygian"},
+        "min_match": 2,
+        "overrides": {
+            "tempo": ParamDistribution("gaussian", center=118, spread=8),
+            "density": ParamDistribution("discrete", weights={"medium": 0.6, "dense": 0.4}),
+            "dynamics": ParamDistribution("discrete", weights={"mf": 0.4, "f": 0.4, "mp": 0.2}),
+        },
+    },
+    "neo-soul": {
+        "label": "Neo-Soul",
+        "keywords": {
+            "neo-soul",
+            "neo soul",
+            "soul",
+            "warm",
+            "smooth",
+            "keys",
+            "piano",
+            "bass",
+            "groove",
+            "organic",
+        },
+        "modes": {"dorian", "mixolydian", "minor"},
+        "min_match": 2,
+        "overrides": {
+            "tempo": ParamDistribution("gaussian", center=85, spread=8),
+            "groove_strength": ParamDistribution("range", min=0.6, max=0.85, bias=0.75),
+            "timing_feel": ParamDistribution("discrete", weights={"behind": 0.7, "on": 0.3}),
+        },
+    },
+}
+
+
+class TextToIntentService:
+    """
+    Convert free-text music descriptions into probabilistic parameter
+    distributions.
+
+    Uses:
+    - TextEmotionParser for emotional valence/arousal
+    - KeywordExtractor for concrete musical terms
+    - CLUSTER_TRIGGERS for context-dependent interpretation
+    - MusicalParameters (from emotional_mapping) for emotion→music mapping
+    """
+
+    def __init__(self):
+        self.keyword_extractor = KeywordExtractor()
+
+    def parse(
+        self,
+        text: str,
+        locale: str = "en",
+        user_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Parse text into probabilistic musical parameters.
+
+        Returns a dict matching the ParseTextResponse schema expected by
+        the frontend.
+        """
+        # 1. Extract musical keywords
+        keywords = self.keyword_extractor.extract(text)
+
+        # 2. Parse emotion (optional — works without it)
+        emotion_distributions = self._parse_emotion(text)
+
+        # 3. Match context clusters
+        clusters = self._match_clusters(keywords)
+
+        # 4. Merge distributions: emotion base + cluster overrides
+        merged = self._merge_distributions(emotion_distributions, clusters)
+
+        # 5. Inject keyword-derived distributions
+        if keywords.mode_words:
+            merged = self._apply_mode_keywords(merged, keywords.mode_words)
+
+        # 6. Build taxonomy node activations
+        taxonomy_ids = list(set(keywords.taxonomy_hints))
+
+        # 7. Calculate overall confidence
+        confidence = self._calculate_confidence(keywords, clusters)
+
+        return {
+            "param_distributions": {k: v.to_dict() for k, v in merged.items()},
+            "activated_clusters": [
+                {"id": c_id, "confidence": c_data["score"], "label": c_data["label"]}
+                for c_id, c_data in clusters.items()
+            ],
+            "activated_taxonomy_ids": taxonomy_ids,
+            "detected_keywords": keywords.all_matched,
+            "confidence": confidence,
+        }
+
+    def _parse_emotion(self, text: str) -> Dict[str, ParamDistribution]:
+        """Use TextEmotionParser + emotional_mapping for emotion-based params."""
+        distributions: Dict[str, ParamDistribution] = {}
+
+        parser = _get_emotion_parser()
+        mapping = _get_emotional_mapping()
+
+        if parser is None or mapping is None:
+            return distributions
+
+        try:
+            parsed = parser.parse(text)
+            emotional_state_dict = parsed.to_emotional_state_dict()
+
+            # Create EmotionalState
+            state = mapping.EmotionalState(
+                valence=emotional_state_dict["valence"],
+                arousal=emotional_state_dict["arousal"],
+                primary_emotion=emotional_state_dict["primary_emotion"],
+                secondary_emotions=emotional_state_dict.get("secondary_emotions", []),
+                has_intrusions=emotional_state_dict.get("has_intrusions", False),
+            )
+
+            # Get musical parameters (already has ranges + distributions!)
+            params = mapping.get_parameters_for_state(state)
+
+            # Convert MusicalParameters to ParamDistribution objects
+            distributions["tempo"] = ParamDistribution(
+                "gaussian",
+                center=params.tempo_suggested,
+                spread=(params.tempo_max - params.tempo_min) / 4,
+            )
+            distributions["mode_weights"] = ParamDistribution(
+                "discrete",
+                weights=dict(params.mode_weights),
+            )
+            distributions["density"] = ParamDistribution(
+                "discrete",
+                weights=(
+                    {params.density.value: 0.7, "medium": 0.3}
+                    if params.density.value != "medium"
+                    else {"medium": 0.7, "sparse": 0.15, "dense": 0.15}
+                ),
+            )
+            distributions["timing_feel"] = ParamDistribution(
+                "discrete",
+                weights=(
+                    {params.timing_feel.value: 0.7, "on": 0.3}
+                    if params.timing_feel.value != "on"
+                    else {"on": 0.6, "behind": 0.2, "ahead": 0.2}
+                ),
+            )
+            distributions["dynamics"] = ParamDistribution(
+                "discrete",
+                weights=(
+                    {params.dynamics: 0.6, "mf": 0.2, "mp": 0.2}
+                    if params.dynamics not in ("mf", "mp")
+                    else {params.dynamics: 0.5, "f": 0.25, "p": 0.25}
+                ),
+            )
+            distributions["space_probability"] = ParamDistribution(
+                "range",
+                min=max(0, params.space_probability - 0.1),
+                max=min(1, params.space_probability + 0.1),
+                bias=params.space_probability,
+            )
+            distributions["dissonance"] = ParamDistribution(
+                "range",
+                min=max(0, params.dissonance - 0.1),
+                max=min(1, params.dissonance + 0.1),
+                bias=params.dissonance,
+            )
+        except Exception:
+            pass
+
+        return distributions
+
+    def _match_clusters(self, keywords: ExtractedKeywords) -> Dict[str, Dict[str, Any]]:
+        """Match extracted keywords against cluster triggers."""
+        matched: Dict[str, Dict[str, Any]] = {}
+        all_words = set(w.lower() for w in keywords.all_matched)
+        all_modes = set(w.lower() for w in keywords.mode_words)
+
+        for cluster_id, cluster_def in CLUSTER_TRIGGERS.items():
+            trigger_keywords = cluster_def["keywords"]
+            trigger_modes = cluster_def["modes"]
+            min_match = cluster_def.get("min_match", 2)
+
+            # Count keyword matches
+            keyword_matches = all_words & trigger_keywords
+            mode_matches = all_modes & trigger_modes
+
+            total_matches = len(keyword_matches) + len(mode_matches)
+
+            if total_matches >= min_match:
+                score = min(1.0, total_matches / max(1, min_match + 1))
+                matched[cluster_id] = {
+                    "score": round(score, 3),
+                    "label": cluster_def["label"],
+                    "matched_keywords": list(keyword_matches),
+                    "matched_modes": list(mode_matches),
+                    "overrides": cluster_def["overrides"],
+                }
+
+        # Sort by score, keep top 5
+        sorted_clusters = dict(
+            sorted(matched.items(), key=lambda x: x[1]["score"], reverse=True)[:5]
+        )
+        return sorted_clusters
+
+    def _merge_distributions(
+        self,
+        emotion_base: Dict[str, ParamDistribution],
+        clusters: Dict[str, Dict[str, Any]],
+    ) -> Dict[str, ParamDistribution]:
+        """Merge emotion-derived distributions with cluster overrides."""
+        merged = dict(emotion_base)
+
+        # Apply cluster overrides weighted by score, weakest first so the
+        # highest-scored cluster has the final (strongest) say.
+        for cluster_id, cluster_data in reversed(list(clusters.items())):
+            score = cluster_data["score"]
+            overrides: Dict[str, ParamDistribution] = cluster_data["overrides"]
+
+            for param, dist in overrides.items():
+                if param not in merged:
+                    merged[param] = dist
+                else:
+                    # Blend: cluster with high score overrides more
+                    existing = merged[param]
+                    merged[param] = self._blend_distributions(existing, dist, score)
+
+        # Default distributions for params that weren't set
+        if "tempo" not in merged:
+            merged["tempo"] = ParamDistribution("gaussian", center=120, spread=20)
+        if "mode_weights" not in merged:
+            merged["mode_weights"] = ParamDistribution(
+                "discrete",
+                weights={
+                    "major": 0.25,
+                    "minor": 0.25,
+                    "dorian": 0.15,
+                    "mixolydian": 0.15,
+                    "lydian": 0.1,
+                    "phrygian": 0.1,
+                },
+            )
+        if "density" not in merged:
+            merged["density"] = ParamDistribution(
+                "discrete",
+                weights={"sparse": 0.3, "medium": 0.4, "dense": 0.3},
+            )
+
+        return merged
+
+    def _blend_distributions(
+        self,
+        a: ParamDistribution,
+        b: ParamDistribution,
+        b_weight: float,
+    ) -> ParamDistribution:
+        """Blend two distributions, with b weighted by b_weight."""
+        a_weight = 1.0 - b_weight
+
+        if a.type == "gaussian" and b.type == "gaussian":
+            return ParamDistribution(
+                "gaussian",
+                center=(a.center or 0) * a_weight + (b.center or 0) * b_weight,
+                spread=max(a.spread or 0, b.spread or 0),
+            )
+        elif a.type == "discrete" and b.type == "discrete":
+            merged_weights: Dict[str, float] = {}
+            all_keys = set(list(a.weights or {}) + list(b.weights or {}))
+            for k in all_keys:
+                av = (a.weights or {}).get(k, 0)
+                bv = (b.weights or {}).get(k, 0)
+                merged_weights[k] = av * a_weight + bv * b_weight
+            # Normalize
+            total = sum(merged_weights.values())
+            if total > 0:
+                merged_weights = {k: v / total for k, v in merged_weights.items()}
+            return ParamDistribution("discrete", weights=merged_weights)
+        elif a.type == "range" and b.type == "range":
+            return ParamDistribution(
+                "range",
+                min=(a.min or 0) * a_weight + (b.min or 0) * b_weight,
+                max=(a.max or 1) * a_weight + (b.max or 1) * b_weight,
+                bias=(a.bias or 0.5) * a_weight + (b.bias or 0.5) * b_weight,
+            )
+        else:
+            # Type mismatch — higher weight wins
+            return b if b_weight > 0.5 else a
+
+    def _apply_mode_keywords(
+        self,
+        distributions: Dict[str, ParamDistribution],
+        mode_words: List[str],
+    ) -> Dict[str, ParamDistribution]:
+        """Boost mode weights for explicitly mentioned modes."""
+        if "mode_weights" not in distributions:
+            distributions["mode_weights"] = ParamDistribution("discrete", weights={})
+
+        weights = dict(distributions["mode_weights"].weights or {})
+
+        # Boost mentioned modes significantly
+        for mode in mode_words:
+            canonical = mode.lower().replace(" ", "_")
+            # Map some aliases
+            alias_map = {
+                "pentatonic": "pentatonic_minor",
+                "minor_pentatonic": "pentatonic_minor",
+                "major_pentatonic": "pentatonic_major",
+                "blues_scale": "blues",
+                "harmonic_minor": "harmonic_minor",
+                "melodic_minor": "melodic_minor",
+                "aeolian": "minor",
+            }
+            canonical = alias_map.get(canonical, canonical)
+            weights[canonical] = weights.get(canonical, 0) + 0.5
+
+        # Normalize
+        total = sum(weights.values())
+        if total > 0:
+            weights = {k: round(v / total, 3) for k, v in weights.items()}
+
+        distributions["mode_weights"] = ParamDistribution("discrete", weights=weights)
+        return distributions
+
+    def _calculate_confidence(
+        self,
+        keywords: ExtractedKeywords,
+        clusters: Dict[str, Dict[str, Any]],
+    ) -> float:
+        """Calculate overall interpretation confidence."""
+        keyword_score = min(1.0, len(keywords.all_matched) / 5)
+        cluster_score = max(c["score"] for c in clusters.values()) if clusters else 0.3
+        return round((keyword_score * 0.4 + cluster_score * 0.6), 3)

--- a/src/AppConsole.tsx
+++ b/src/AppConsole.tsx
@@ -12,10 +12,11 @@ import LyricPanel from './components/LyricPanel';
 import { SpectoCloudPanel } from './components/SpectoCloudPanel';
 import { MusicCustomizer } from './components/MusicCustomizer';
 import { RotaryModeSelector } from './components/RotaryModeSelector';
+import UniversalMusicInput from './components/UniversalMusicInput/UniversalMusicInput';
 import { useMusicBrain } from './hooks/useMusicBrain';
 import './console-shell.css';
 
-type Mode = 'mix-detail' | 'inspire' | 'create' | 'compose';
+type Mode = 'mix-detail' | 'inspire' | 'create' | 'compose' | 'universal';
 
 /**
  * Feature flag: swap the vertical NavRail for the tactile rotary mode
@@ -93,6 +94,17 @@ const NAV_ITEMS: { id: Mode; label: string; icon: ReactNode }[] = [
         <rect x="11" y="3" width="6" height="6" rx="1" />
         <rect x="3" y="11" width="6" height="6" rx="1" />
         <rect x="11" y="11" width="6" height="6" rx="1" />
+      </svg>
+    ),
+  },
+  {
+    id: 'universal',
+    label: 'Universal Input',
+    icon: (
+      <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5">
+        <rect x="3" y="3" width="6.5" height="14" rx="1" />
+        <rect x="10.5" y="3" width="6.5" height="14" rx="1" />
+        <path d="M12.5 7h2.5M12.5 10h2.5M12.5 13h1.5" />
       </svg>
     ),
   },
@@ -436,6 +448,12 @@ export default function AppConsole() {
           {displayMode === 'compose' && (
             <section className="mode-compose mode-enter" aria-label="Intent Builder">
               <IntentBuilder />
+            </section>
+          )}
+
+          {displayMode === 'universal' && (
+            <section className="mode-universal mode-enter" aria-label="Universal music input">
+              <UniversalMusicInput apiStatus={apiStatus} />
             </section>
           )}
         </div>

--- a/src/components/UniversalMusicInput/CommandPalette.tsx
+++ b/src/components/UniversalMusicInput/CommandPalette.tsx
@@ -1,0 +1,56 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+
+interface CommandPaletteProps {
+  searchQuery: string;
+  onSearchChange: (query: string) => void;
+  /** Total active nodes for display */
+  activeCount: number;
+}
+
+export function CommandPalette({ searchQuery, onSearchChange, activeCount }: CommandPaletteProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Cmd+K / Ctrl+K to focus
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault();
+        inputRef.current?.focus();
+      }
+      if (e.key === 'Escape' && document.activeElement === inputRef.current) {
+        onSearchChange('');
+        inputRef.current?.blur();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onSearchChange]);
+
+  return (
+    <div className="umi-command-palette">
+      <div className="umi-search-box">
+        <span className="umi-search-icon">⌕</span>
+        <input
+          ref={inputRef}
+          type="text"
+          className="umi-search-input"
+          placeholder="Search commands... (⌘K)"
+          value={searchQuery}
+          onChange={e => onSearchChange(e.target.value)}
+        />
+        {searchQuery && (
+          <button
+            type="button"
+            className="umi-search-clear"
+            onClick={() => onSearchChange('')}
+          >
+            ✕
+          </button>
+        )}
+      </div>
+      {activeCount > 0 && (
+        <span className="umi-active-count">{activeCount} active</span>
+      )}
+    </div>
+  );
+}

--- a/src/components/UniversalMusicInput/ContextFeedback.tsx
+++ b/src/components/UniversalMusicInput/ContextFeedback.tsx
@@ -1,0 +1,87 @@
+import type { ParseTextResponse } from '../../types/Interpretation';
+
+interface ContextFeedbackProps {
+  parseResult: ParseTextResponse | null;
+  onReinterpret: () => void;
+}
+
+export function ContextFeedback({ parseResult, onReinterpret }: ContextFeedbackProps) {
+  if (!parseResult) return null;
+
+  const topCluster = parseResult.activated_clusters[0];
+  const modeWeights = parseResult.param_distributions.mode_weights;
+  const tempoDistribution = parseResult.param_distributions.tempo;
+
+  return (
+    <div className="umi-context-feedback">
+      {/* Active cluster */}
+      {topCluster && (
+        <div className="umi-cluster-badge">
+          <span className="umi-cluster-label">{topCluster.label}</span>
+          <span className="umi-cluster-confidence">
+            {Math.round(topCluster.confidence * 100)}%
+          </span>
+        </div>
+      )}
+
+      {/* Detected keywords */}
+      {parseResult.detected_keywords.length > 0 && (
+        <div className="umi-detected-keywords">
+          {parseResult.detected_keywords.map(kw => (
+            <span key={kw} className="umi-keyword-tag">{kw}</span>
+          ))}
+        </div>
+      )}
+
+      {/* Mode distribution bar */}
+      {modeWeights?.weights && (
+        <div className="umi-distribution-bar">
+          <span className="umi-dist-label">Mode:</span>
+          <div className="umi-dist-segments">
+            {Object.entries(modeWeights.weights)
+              .filter(([, w]) => w > 0.05)
+              .sort(([, a], [, b]) => b - a)
+              .map(([mode, weight]) => (
+                <div
+                  key={mode}
+                  className="umi-dist-segment"
+                  style={{ flex: weight }}
+                  title={`${mode}: ${Math.round(weight * 100)}%`}
+                >
+                  <span className="umi-dist-segment-label">
+                    {mode} {Math.round(weight * 100)}%
+                  </span>
+                </div>
+              ))}
+          </div>
+        </div>
+      )}
+
+      {/* Tempo range */}
+      {tempoDistribution?.center && (
+        <div className="umi-tempo-range">
+          <span className="umi-dist-label">Tempo:</span>
+          <span className="umi-tempo-value">
+            ~{Math.round(tempoDistribution.center - (tempoDistribution.spread ?? 10))}
+            –{Math.round(tempoDistribution.center + (tempoDistribution.spread ?? 10))} BPM
+          </span>
+        </div>
+      )}
+
+      {/* Overall confidence */}
+      <div className="umi-confidence-row">
+        <span className="umi-confidence-label">
+          Confidence: {Math.round(parseResult.confidence * 100)}%
+        </span>
+        <button
+          type="button"
+          className="umi-reinterpret-btn"
+          onClick={onReinterpret}
+          title="Re-sample from same distributions"
+        >
+          🎲 Reinterpret
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/UniversalMusicInput/IntentSummaryBar.tsx
+++ b/src/components/UniversalMusicInput/IntentSummaryBar.tsx
@@ -1,0 +1,44 @@
+import type { ParseTextResponse } from '../../types/Interpretation';
+
+interface IntentSummaryBarProps {
+  summary: string;
+  isValid: boolean;
+  isGenerating: boolean;
+  apiStatus: 'checking' | 'online' | 'offline';
+  onGenerate: () => void;
+  onReinterpret: () => void;
+}
+
+export function IntentSummaryBar({
+  summary, isValid, isGenerating, apiStatus, onGenerate, onReinterpret,
+}: IntentSummaryBarProps) {
+  return (
+    <div className="umi-summary-bar">
+      <div className="umi-summary-text">
+        {summary || 'Select commands or describe your music to begin...'}
+      </div>
+      <div className="umi-summary-actions">
+        <button
+          type="button"
+          className="umi-reinterpret-btn-sm"
+          onClick={onReinterpret}
+          title="Re-sample from current distributions"
+        >
+          🎲
+        </button>
+        <button
+          type="button"
+          className="umi-generate-btn"
+          onClick={onGenerate}
+          disabled={!isValid || isGenerating || apiStatus !== 'online'}
+        >
+          {isGenerating ? 'Generating...' : '▶ Generate'}
+        </button>
+        <span className={`umi-api-status ${apiStatus}`}>
+          <span className="umi-status-dot" />
+          {apiStatus === 'online' ? 'Online' : apiStatus === 'offline' ? 'Offline' : '...'}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/UniversalMusicInput/InterpretiveSlider.tsx
+++ b/src/components/UniversalMusicInput/InterpretiveSlider.tsx
@@ -1,0 +1,24 @@
+interface InterpretiveSliderProps {
+  value: number; // 0 = literal, 1 = surprise
+  onChange: (value: number) => void;
+}
+
+export function InterpretiveSlider({ value, onChange }: InterpretiveSliderProps) {
+  return (
+    <div className="umi-interpretive-slider">
+      <label className="umi-slider-label">
+        <span className="umi-slider-end">Literal</span>
+        <input
+          type="range"
+          min={0}
+          max={1}
+          step={0.05}
+          value={value}
+          onChange={e => onChange(parseFloat(e.target.value))}
+          className="umi-slider-input"
+        />
+        <span className="umi-slider-end">Surprise</span>
+      </label>
+    </div>
+  );
+}

--- a/src/components/UniversalMusicInput/NaturalLanguageInput.tsx
+++ b/src/components/UniversalMusicInput/NaturalLanguageInput.tsx
@@ -1,0 +1,34 @@
+import { useCallback, useRef } from 'react';
+
+interface NaturalLanguageInputProps {
+  value: string;
+  isParsing: boolean;
+  onChange: (text: string) => void;
+}
+
+export function NaturalLanguageInput({ value, isParsing, onChange }: NaturalLanguageInputProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const handleChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    onChange(e.target.value);
+  }, [onChange]);
+
+  return (
+    <div className="umi-nl-input-wrap">
+      <textarea
+        ref={textareaRef}
+        className="umi-nl-textarea"
+        placeholder="Describe the music you hear in your head...&#10;&#10;Examples:&#10;• &quot;dorian with fast guitar licks and lots of overdrive&quot;&#10;• &quot;slow clean bass, pentatonic, bluesy feel&quot;&#10;• &quot;a thunderstorm clearing into sunshine&quot;&#10;• &quot;laid-back neo-soul with warm keys&quot;"
+        value={value}
+        onChange={handleChange}
+        rows={6}
+      />
+      {isParsing && (
+        <div className="umi-parsing-indicator">
+          <span className="umi-parsing-dot" />
+          interpreting...
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/UniversalMusicInput/SideAPane.tsx
+++ b/src/components/UniversalMusicInput/SideAPane.tsx
@@ -1,0 +1,59 @@
+import { CommandPalette } from './CommandPalette';
+import { TaxonomyTree } from './TaxonomyTree';
+import { InterpretiveSlider } from './InterpretiveSlider';
+
+interface TaxonomyNode {
+  id: string;
+  label: string;
+  children?: TaxonomyNode[];
+  keywords: string[];
+}
+
+interface SideAPaneProps {
+  taxonomyNodes: TaxonomyNode[];
+  nodeWeights: Map<string, number>;
+  nlpDetectedNodes: Set<string>;
+  pinnedNodes: Set<string>;
+  searchQuery: string;
+  interpretiveLevel: number;
+  onSearchChange: (query: string) => void;
+  onToggleNode: (id: string) => void;
+  onPinNode: (id: string) => void;
+  onInterpretiveLevelChange: (level: number) => void;
+}
+
+export function SideAPane({
+  taxonomyNodes, nodeWeights, nlpDetectedNodes, pinnedNodes,
+  searchQuery, interpretiveLevel,
+  onSearchChange, onToggleNode, onPinNode, onInterpretiveLevelChange,
+}: SideAPaneProps) {
+  const activeCount = nodeWeights.size;
+
+  return (
+    <div className="umi-side-a">
+      <div className="umi-side-header">
+        <h2 className="umi-side-title">Musical Commands</h2>
+      </div>
+      <CommandPalette
+        searchQuery={searchQuery}
+        onSearchChange={onSearchChange}
+        activeCount={activeCount}
+      />
+      <div className="umi-tree-scroll">
+        <TaxonomyTree
+          nodes={taxonomyNodes}
+          nodeWeights={nodeWeights}
+          nlpDetectedNodes={nlpDetectedNodes}
+          pinnedNodes={pinnedNodes}
+          searchQuery={searchQuery}
+          onToggleNode={onToggleNode}
+          onPinNode={onPinNode}
+        />
+      </div>
+      <InterpretiveSlider
+        value={interpretiveLevel}
+        onChange={onInterpretiveLevelChange}
+      />
+    </div>
+  );
+}

--- a/src/components/UniversalMusicInput/SideBPane.tsx
+++ b/src/components/UniversalMusicInput/SideBPane.tsx
@@ -1,0 +1,32 @@
+import { NaturalLanguageInput } from './NaturalLanguageInput';
+import { ContextFeedback } from './ContextFeedback';
+import type { ParseTextResponse } from '../../types/Interpretation';
+
+interface SideBPaneProps {
+  text: string;
+  isParsing: boolean;
+  parseResult: ParseTextResponse | null;
+  onTextChange: (text: string) => void;
+  onReinterpret: () => void;
+}
+
+export function SideBPane({
+  text, isParsing, parseResult, onTextChange, onReinterpret,
+}: SideBPaneProps) {
+  return (
+    <div className="umi-side-b">
+      <div className="umi-side-header">
+        <h2 className="umi-side-title">Natural Language</h2>
+      </div>
+      <NaturalLanguageInput
+        value={text}
+        isParsing={isParsing}
+        onChange={onTextChange}
+      />
+      <ContextFeedback
+        parseResult={parseResult}
+        onReinterpret={onReinterpret}
+      />
+    </div>
+  );
+}

--- a/src/components/UniversalMusicInput/TaxonomyNodeChip.tsx
+++ b/src/components/UniversalMusicInput/TaxonomyNodeChip.tsx
@@ -1,0 +1,54 @@
+import { useCallback } from 'react';
+
+interface TaxonomyNodeChipProps {
+  id: string;
+  label: string;
+  /** 0-1 probability weight (undefined = not active) */
+  weight?: number;
+  /** Whether this node was detected via NLP (vs manually selected) */
+  isNlpDetected?: boolean;
+  /** Whether this node's parameter is pinned */
+  isPinned?: boolean;
+  onToggle: (id: string) => void;
+  onPin?: (id: string) => void;
+}
+
+export function TaxonomyNodeChip({
+  id, label, weight, isNlpDetected, isPinned, onToggle, onPin,
+}: TaxonomyNodeChipProps) {
+  const isActive = weight !== undefined && weight > 0;
+  const handleClick = useCallback(() => onToggle(id), [id, onToggle]);
+  const handlePin = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    onPin?.(id);
+  }, [id, onPin]);
+
+  const weightPercent = weight !== undefined ? Math.round(weight * 100) : 0;
+  const fillWidth = isActive ? `${Math.max(8, weightPercent)}%` : '0%';
+
+  return (
+    <button
+      type="button"
+      className={`umi-node-chip${isActive ? ' active' : ''}${isNlpDetected ? ' nlp-detected' : ''}`}
+      onClick={handleClick}
+      title={`${label}${isActive ? ` (${weightPercent}%)` : ''}`}
+    >
+      <span className="umi-node-chip-fill" style={{ width: fillWidth }} />
+      <span className="umi-node-chip-label">{label}</span>
+      {isActive && (
+        <span className="umi-node-chip-weight">{weightPercent}%</span>
+      )}
+      {isActive && onPin && (
+        <span
+          className={`umi-node-chip-pin${isPinned ? ' pinned' : ''}`}
+          onClick={handlePin}
+          role="button"
+          tabIndex={0}
+          title={isPinned ? 'Unpin' : 'Pin this value'}
+        >
+          {isPinned ? '📌' : '📍'}
+        </span>
+      )}
+    </button>
+  );
+}

--- a/src/components/UniversalMusicInput/TaxonomyTree.tsx
+++ b/src/components/UniversalMusicInput/TaxonomyTree.tsx
@@ -1,0 +1,154 @@
+import { useState, useCallback, useMemo } from 'react';
+import { TaxonomyNodeChip } from './TaxonomyNodeChip';
+
+interface TaxonomyNode {
+  id: string;
+  label: string;
+  children?: TaxonomyNode[];
+  keywords: string[];
+}
+
+interface TaxonomyTreeProps {
+  /** The full taxonomy tree data */
+  nodes: TaxonomyNode[];
+  /** Weights for active nodes: nodeId → weight (0-1) */
+  nodeWeights: Map<string, number>;
+  /** Nodes detected by NLP (displayed differently) */
+  nlpDetectedNodes: Set<string>;
+  /** Pinned parameters */
+  pinnedNodes: Set<string>;
+  /** Search query for filtering */
+  searchQuery: string;
+  onToggleNode: (id: string) => void;
+  onPinNode?: (id: string) => void;
+}
+
+export function TaxonomyTree({
+  nodes, nodeWeights, nlpDetectedNodes, pinnedNodes,
+  searchQuery, onToggleNode, onPinNode,
+}: TaxonomyTreeProps) {
+  return (
+    <div className="umi-taxonomy-tree">
+      {nodes.map(node => (
+        <TreeBranch
+          key={node.id}
+          node={node}
+          depth={0}
+          nodeWeights={nodeWeights}
+          nlpDetectedNodes={nlpDetectedNodes}
+          pinnedNodes={pinnedNodes}
+          searchQuery={searchQuery}
+          onToggleNode={onToggleNode}
+          onPinNode={onPinNode}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface TreeBranchProps {
+  node: TaxonomyNode;
+  depth: number;
+  nodeWeights: Map<string, number>;
+  nlpDetectedNodes: Set<string>;
+  pinnedNodes: Set<string>;
+  searchQuery: string;
+  onToggleNode: (id: string) => void;
+  onPinNode?: (id: string) => void;
+}
+
+function TreeBranch({
+  node, depth, nodeWeights, nlpDetectedNodes, pinnedNodes,
+  searchQuery, onToggleNode, onPinNode,
+}: TreeBranchProps) {
+  const [isExpanded, setIsExpanded] = useState(depth === 0);
+
+  const hasChildren = node.children && node.children.length > 0;
+  const isLeaf = !hasChildren;
+
+  // Check if this node or any descendant matches the search
+  const matchesSearch = useMemo(() => {
+    if (!searchQuery) return true;
+    const q = searchQuery.toLowerCase();
+    return nodeMatchesSearch(node, q);
+  }, [node, searchQuery]);
+
+  // Auto-expand when search matches a descendant
+  const shouldShow = matchesSearch;
+  const shouldAutoExpand = searchQuery.length > 0 && matchesSearch;
+
+  const toggle = useCallback(() => setIsExpanded(v => !v), []);
+
+  // Count active children for the badge
+  const activeChildCount = useMemo(() => {
+    if (!hasChildren) return 0;
+    return countActiveDescendants(node, nodeWeights);
+  }, [node, nodeWeights, hasChildren]);
+
+  if (!shouldShow) return null;
+
+  const expanded = isExpanded || shouldAutoExpand;
+
+  if (isLeaf) {
+    return (
+      <TaxonomyNodeChip
+        id={node.id}
+        label={node.label}
+        weight={nodeWeights.get(node.id)}
+        isNlpDetected={nlpDetectedNodes.has(node.id)}
+        isPinned={pinnedNodes.has(node.id)}
+        onToggle={onToggleNode}
+        onPin={onPinNode}
+      />
+    );
+  }
+
+  return (
+    <div className="umi-tree-branch" data-depth={depth}>
+      <button
+        type="button"
+        className={`umi-tree-header${expanded ? ' expanded' : ''}`}
+        onClick={toggle}
+      >
+        <span className="umi-tree-arrow">{expanded ? '▼' : '▶'}</span>
+        <span className="umi-tree-label">{node.label}</span>
+        {activeChildCount > 0 && (
+          <span className="umi-tree-badge">{activeChildCount}</span>
+        )}
+      </button>
+      {expanded && node.children && (
+        <div className="umi-tree-children">
+          {node.children.map(child => (
+            <TreeBranch
+              key={child.id}
+              node={child}
+              depth={depth + 1}
+              nodeWeights={nodeWeights}
+              nlpDetectedNodes={nlpDetectedNodes}
+              pinnedNodes={pinnedNodes}
+              searchQuery={searchQuery}
+              onToggleNode={onToggleNode}
+              onPinNode={onPinNode}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function nodeMatchesSearch(node: TaxonomyNode, query: string): boolean {
+  if (node.label.toLowerCase().includes(query)) return true;
+  if (node.keywords.some(k => k.toLowerCase().includes(query))) return true;
+  if (node.children?.some(c => nodeMatchesSearch(c, query))) return true;
+  return false;
+}
+
+function countActiveDescendants(node: TaxonomyNode, weights: Map<string, number>): number {
+  let count = 0;
+  if (!node.children) return weights.has(node.id) ? 1 : 0;
+  for (const child of node.children) {
+    count += countActiveDescendants(child, weights);
+  }
+  return count;
+}

--- a/src/components/UniversalMusicInput/ToolDrawer.tsx
+++ b/src/components/UniversalMusicInput/ToolDrawer.tsx
@@ -1,0 +1,27 @@
+import { useState, type ReactNode } from 'react';
+
+interface ToolDrawerProps {
+  children: ReactNode;
+}
+
+export function ToolDrawer({ children }: ToolDrawerProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        type="button"
+        className="umi-drawer-toggle"
+        onClick={() => setIsOpen(v => !v)}
+        title={isOpen ? 'Hide tools' : 'Show Mix/Transport/Lyrics tools'}
+      >
+        {isOpen ? '▼ Tools' : '▲ Tools'}
+      </button>
+      {isOpen && (
+        <div className="umi-drawer">
+          {children}
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/UniversalMusicInput/UniversalMusicInput.tsx
+++ b/src/components/UniversalMusicInput/UniversalMusicInput.tsx
@@ -1,0 +1,266 @@
+import { useState, useCallback, useMemo, useEffect } from 'react';
+import { SideAPane } from './SideAPane';
+import { SideBPane } from './SideBPane';
+import { IntentSummaryBar } from './IntentSummaryBar';
+import { ToolDrawer } from './ToolDrawer';
+import { useTextParse } from '../../hooks/useTextParse';
+import { useMusicBrain, buildGeneratePayload } from '../../hooks/useMusicBrain';
+import type { CompleteSongIntentRequest } from '../../types/Intent';
+import type { ParseTextResponse } from '../../types/Interpretation';
+import { TAXONOMY_TREE } from '../../data/taxonomyTree';
+
+interface UniversalMusicInputProps {
+  apiStatus: 'checking' | 'online' | 'offline';
+  /** Existing components to place in the ToolDrawer */
+  toolDrawerContent?: React.ReactNode;
+}
+
+export default function UniversalMusicInput({ apiStatus, toolDrawerContent }: UniversalMusicInputProps) {
+  // --- State ---
+  const [searchQuery, setSearchQuery] = useState('');
+  const [naturalText, setNaturalText] = useState('');
+  const [activeNodes, setActiveNodes] = useState<Set<string>>(new Set());
+  const [pinnedNodes, setPinnedNodes] = useState<Set<string>>(new Set());
+  const [interpretiveLevel, setInterpretiveLevel] = useState(0.5);
+  const [isGenerating, setIsGenerating] = useState(false);
+
+  const brain = useMusicBrain();
+  const { parseResult, isParsing, parseDebounced, forceReparse } = useTextParse();
+
+  // NLP-detected nodes from parse result
+  const nlpDetectedNodes = useMemo(() => {
+    if (!parseResult) return new Set<string>();
+    return new Set(parseResult.activated_taxonomy_ids);
+  }, [parseResult]);
+
+  // Combined node weights: manual nodes get weight 1.0, NLP nodes get their confidence
+  const nodeWeights = useMemo(() => {
+    const weights = new Map<string, number>();
+    // Manual selections at full weight
+    for (const id of activeNodes) {
+      weights.set(id, 1.0);
+    }
+    // NLP detections at confidence-scaled weight (won't override manual)
+    if (parseResult) {
+      const conf = parseResult.confidence;
+      for (const id of parseResult.activated_taxonomy_ids) {
+        if (!weights.has(id)) {
+          weights.set(id, conf * 0.85);
+        }
+      }
+    }
+    return weights;
+  }, [activeNodes, parseResult]);
+
+  // --- Handlers ---
+  const handleTextChange = useCallback((text: string) => {
+    setNaturalText(text);
+    parseDebounced(text);
+  }, [parseDebounced]);
+
+  const handleToggleNode = useCallback((id: string) => {
+    setActiveNodes(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const handlePinNode = useCallback((id: string) => {
+    setPinnedNodes(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleReinterpret = useCallback(() => {
+    if (naturalText.trim()) {
+      forceReparse();
+    }
+  }, [naturalText, forceReparse]);
+
+  // --- Summary ---
+  const summary = useMemo(() => {
+    const parts: string[] = [];
+
+    if (parseResult?.activated_clusters[0]) {
+      parts.push(parseResult.activated_clusters[0].label);
+    }
+
+    const modeWeights = parseResult?.param_distributions?.mode_weights?.weights;
+    if (modeWeights) {
+      const topMode = Object.entries(modeWeights).sort(([, a], [, b]) => b - a)[0];
+      if (topMode) {
+        parts.push(`${topMode[0]} ${Math.round(topMode[1] * 100)}%`);
+      }
+    }
+
+    const tempo = parseResult?.param_distributions?.tempo;
+    if (tempo?.center) {
+      const spread = tempo.spread ?? 10;
+      parts.push(`~${Math.round(tempo.center - spread)}–${Math.round(tempo.center + spread)} BPM`);
+    }
+
+    if (activeNodes.size > 0) {
+      parts.push(`${activeNodes.size} selected`);
+    }
+
+    return parts.join(' · ') || '';
+  }, [parseResult, activeNodes]);
+
+  const isValid = activeNodes.size > 0 || (parseResult?.detected_keywords?.length ?? 0) > 0;
+
+  // --- Generate ---
+  const handleGenerate = useCallback(async () => {
+    if (!isValid || isGenerating) return;
+    setIsGenerating(true);
+
+    try {
+      // Build a CompleteSongIntentRequest from the current interpretation
+      const intent: CompleteSongIntentRequest = {
+        core_desire: naturalText || 'Generated from Universal Music Input',
+        mood_primary: parseResult?.activated_clusters[0]?.label ?? 'Neutral',
+        genre: parseResult?.activated_clusters[0]?.label ?? '',
+        tempo: parseResult?.param_distributions?.tempo?.center
+          ? Math.round(parseResult.param_distributions.tempo.center)
+          : 120,
+        key_mode: buildKeyModeFromWeights(
+          parseResult?.param_distributions?.mode_weights?.weights,
+          parseResult?.param_distributions?.key_weights?.weights,
+        ),
+        structure: [
+          { name: 'intro', bars: 4, repetitions: 1 },
+          { name: 'verse', bars: 8, repetitions: 2 },
+          { name: 'chorus', bars: 8, repetitions: 1 },
+        ],
+        instruments: buildInstrumentsFromNodes(activeNodes, nlpDetectedNodes),
+        groove_feel: getGrooveFeel(activeNodes, parseResult),
+        narrative_arc: getNarrativeArc(activeNodes),
+      };
+
+      const payload = buildGeneratePayload(intent);
+      await brain.generateMusic(payload);
+    } catch (err) {
+      console.error('Generation failed:', err);
+    } finally {
+      setIsGenerating(false);
+    }
+  }, [isValid, isGenerating, naturalText, parseResult, activeNodes, nlpDetectedNodes, brain]);
+
+  return (
+    <div className="umi-container">
+      <SideAPane
+        taxonomyNodes={TAXONOMY_TREE}
+        nodeWeights={nodeWeights}
+        nlpDetectedNodes={nlpDetectedNodes}
+        pinnedNodes={pinnedNodes}
+        searchQuery={searchQuery}
+        interpretiveLevel={interpretiveLevel}
+        onSearchChange={setSearchQuery}
+        onToggleNode={handleToggleNode}
+        onPinNode={handlePinNode}
+        onInterpretiveLevelChange={setInterpretiveLevel}
+      />
+      <SideBPane
+        text={naturalText}
+        isParsing={isParsing}
+        parseResult={parseResult}
+        onTextChange={handleTextChange}
+        onReinterpret={handleReinterpret}
+      />
+      <IntentSummaryBar
+        summary={summary}
+        isValid={isValid}
+        isGenerating={isGenerating}
+        apiStatus={apiStatus}
+        onGenerate={handleGenerate}
+        onReinterpret={handleReinterpret}
+      />
+      {toolDrawerContent && (
+        <ToolDrawer>{toolDrawerContent}</ToolDrawer>
+      )}
+    </div>
+  );
+}
+
+// --- Helpers ---
+
+function buildKeyModeFromWeights(
+  modeWeights?: Record<string, number>,
+  keyWeights?: Record<string, number>,
+): string {
+  const mode = modeWeights
+    ? Object.entries(modeWeights).sort(([, a], [, b]) => b - a)[0]?.[0] ?? 'major'
+    : 'major';
+  const key = keyWeights
+    ? Object.entries(keyWeights).sort(([, a], [, b]) => b - a)[0]?.[0] ?? 'C'
+    : 'C';
+  return `${key} ${mode}`;
+}
+
+function buildInstrumentsFromNodes(manual: Set<string>, nlp: Set<string>) {
+  const all = new Set([...manual, ...nlp]);
+  const instruments: Array<{ instrument: string; techniques: string[] }> = [];
+
+  const instrumentMap: Record<string, string> = {
+    'timbre.instruments.piano': 'piano',
+    'timbre.instruments.electric-guitar': 'electric_guitar',
+    'timbre.instruments.acoustic-guitar': 'acoustic_guitar',
+    'timbre.instruments.bass-guitar': 'bass_guitar',
+    'timbre.instruments.synth-lead': 'synth_lead',
+    'timbre.instruments.synth-pad': 'synth_pad',
+    'timbre.instruments.strings': 'strings',
+    'timbre.instruments.brass': 'brass',
+    'timbre.instruments.drums': 'drums',
+    'timbre.instruments.sax': 'saxophone',
+    'timbre.instruments.808': '808_bass',
+  };
+
+  for (const [nodeId, instrumentName] of Object.entries(instrumentMap)) {
+    if (all.has(nodeId)) {
+      instruments.push({ instrument: instrumentName, techniques: [] });
+    }
+  }
+
+  // Default to piano if nothing selected
+  if (instruments.length === 0) {
+    instruments.push({ instrument: 'piano', techniques: [] });
+  }
+
+  return instruments;
+}
+
+function getGrooveFeel(nodes: Set<string>, parseResult: ParseTextResponse | null): string {
+  const grooveNodes: Record<string, string> = {
+    'rhythm.groove-feel.straight-driving': 'Straight/Driving',
+    'rhythm.groove-feel.laid-back': 'Laid Back',
+    'rhythm.groove-feel.swung': 'Swung',
+    'rhythm.groove-feel.syncopated': 'Syncopated',
+  };
+  for (const [nodeId, feel] of Object.entries(grooveNodes)) {
+    if (nodes.has(nodeId)) return feel;
+  }
+  return 'Straight/Driving';
+}
+
+function getNarrativeArc(nodes: Set<string>): string {
+  const arcNodes: Record<string, string> = {
+    'structure.narrative-arc.climb-to-climax': 'Climb-to-Climax',
+    'structure.narrative-arc.slow-reveal': 'Slow Reveal',
+    'structure.narrative-arc.rise-and-fall': 'Rise and Fall',
+    'structure.narrative-arc.sudden-shift': 'Sudden Shift',
+  };
+  for (const [nodeId, arc] of Object.entries(arcNodes)) {
+    if (nodes.has(nodeId)) return arc;
+  }
+  return 'Climb-to-Climax';
+}

--- a/src/console-shell.css
+++ b/src/console-shell.css
@@ -624,3 +624,17 @@
     transition: none;
   }
 }
+
+/* ─── Universal Input mode ─── */
+
+.mode-universal {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: 1fr;
+  height: 100%;
+  min-height: 0;
+}
+
+.mode-universal .umi-container {
+  min-height: 0;
+}

--- a/src/data/contextClusters.ts
+++ b/src/data/contextClusters.ts
@@ -1,0 +1,275 @@
+/**
+ * Context Cluster Registry
+ *
+ * Defines genre/style clusters that activate when certain combinations of
+ * taxonomy nodes and/or keywords are present together. The same musical
+ * parameter (e.g., "dorian mode") means completely different things in
+ * different contexts — clusters capture these emergent meanings.
+ */
+
+import type { ParamDistribution } from '../types/Interpretation';
+
+export interface TriggerRule {
+  requiredNodes?: string[];
+  requiredKeywords?: string[];
+  minMatchCount?: number;
+}
+
+export interface ContextCluster {
+  id: string;
+  label: string;
+  genreHints: string[];
+  triggerConditions: TriggerRule[];
+  parameterOverrides: Record<string, ParamDistribution>;
+}
+
+function g(center: number, spread: number): ParamDistribution {
+  return { type: 'gaussian', center, spread };
+}
+function d(weights: Record<string, number>): ParamDistribution {
+  return { type: 'discrete', weights };
+}
+function r(min: number, max: number, bias: number): ParamDistribution {
+  return { type: 'range', min, max, bias };
+}
+
+export const CONTEXT_CLUSTERS: ContextCluster[] = [
+  {
+    id: 'metal-shred',
+    label: 'Metal/Prog Shred',
+    genreHints: ['metal', 'prog', 'djent', 'shred'],
+    triggerConditions: [{ requiredKeywords: ['fast', 'guitar', 'overdrive', 'distortion', 'metal', 'shred', 'heavy', 'aggressive'], requiredNodes: ['harmony.scales.dorian', 'harmony.scales.phrygian', 'timbre.effects.distortion', 'timbre.effects.overdrive'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(160, 15), density: r(0.8, 1.0, 0.9), dynamics: d({ f: 0.4, ff: 0.6 }), timing_feel: d({ on: 0.6, ahead: 0.4 }), groove_strength: r(0.5, 0.8, 0.6) },
+  },
+  {
+    id: 'blues-slow',
+    label: 'Slow Blues',
+    genreHints: ['blues', 'delta blues', 'slow blues'],
+    triggerConditions: [{ requiredKeywords: ['slow', 'blues', 'bluesy', 'clean', 'pentatonic', 'laid-back', 'soulful'], requiredNodes: ['harmony.scales.pentatonic-minor', 'harmony.scales.blues', 'harmony.scales.minor', 'timbre.effects.clean'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(72, 8), density: d({ sparse: 0.6, medium: 0.4 }), dynamics: d({ mp: 0.5, mf: 0.3, p: 0.2 }), timing_feel: d({ behind: 0.8, on: 0.2 }), space_probability: r(0.2, 0.4, 0.3) },
+  },
+  {
+    id: 'blues-chicago',
+    label: 'Chicago Blues',
+    genreHints: ['blues', 'chicago blues', 'electric blues'],
+    triggerConditions: [{ requiredKeywords: ['blues', 'shuffle', 'overdrive', 'guitar', 'chicago'], requiredNodes: ['harmony.scales.minor', 'harmony.scales.mixolydian', 'rhythm.patterns.shuffle'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(110, 10), density: d({ medium: 0.7, dense: 0.3 }), swing: r(0.4, 0.7, 0.6), dynamics: d({ mf: 0.5, f: 0.3, mp: 0.2 }) },
+  },
+  {
+    id: 'jazz-modal',
+    label: 'Modal Jazz',
+    genreHints: ['jazz', 'modal jazz', 'cool jazz'],
+    triggerConditions: [{ requiredKeywords: ['jazz', 'jazzy', 'modal', 'swing', 'walking bass', 'sax', 'piano'], requiredNodes: ['harmony.scales.dorian', 'harmony.scales.lydian', 'timbre.instruments.sax', 'timbre.instruments.piano'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(130, 20), swing: r(0.5, 0.8, 0.7), density: d({ medium: 0.5, dense: 0.3, sparse: 0.2 }), harmonic_rhythm: d({ fast: 0.5, medium: 0.4, slow: 0.1 }) },
+  },
+  {
+    id: 'jazz-bebop',
+    label: 'Bebop',
+    genreHints: ['jazz', 'bebop', 'hard bop'],
+    triggerConditions: [{ requiredKeywords: ['bebop', 'fast', 'sax', 'trumpet', 'walking bass', 'jazz'], requiredNodes: ['harmony.scales.mixolydian', 'harmony.scales.dorian', 'timbre.instruments.sax', 'timbre.instruments.trumpet'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(200, 25), density: d({ dense: 0.7, medium: 0.3 }), swing: r(0.6, 0.9, 0.75), harmonic_rhythm: d({ fast: 0.7, medium: 0.3 }) },
+  },
+  {
+    id: 'jazz-ballad',
+    label: 'Jazz Ballad',
+    genreHints: ['jazz', 'ballad', 'standards'],
+    triggerConditions: [{ requiredKeywords: ['ballad', 'slow', 'jazz', 'piano', 'brushes', 'gentle'], requiredNodes: ['harmony.scales.major', 'harmony.scales.lydian', 'timbre.instruments.piano'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(65, 8), density: d({ sparse: 0.6, medium: 0.4 }), dynamics: d({ pp: 0.3, p: 0.4, mp: 0.3 }), space_probability: r(0.25, 0.45, 0.35) },
+  },
+  {
+    id: 'ambient-pad',
+    label: 'Ambient Pad',
+    genreHints: ['ambient', 'atmospheric', 'new age'],
+    triggerConditions: [{ requiredKeywords: ['ambient', 'pad', 'atmospheric', 'ethereal', 'dreamy', 'floating', 'spacious', 'drone'], requiredNodes: ['harmony.scales.lydian', 'timbre.instruments.synth-pad', 'timbre.effects.reverb'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(65, 10), density: d({ sparse: 0.7, medium: 0.3 }), dynamics: d({ pp: 0.4, p: 0.4, mp: 0.2 }), space_probability: r(0.3, 0.6, 0.4) },
+  },
+  {
+    id: 'ambient-drone',
+    label: 'Ambient Drone',
+    genreHints: ['ambient', 'drone', 'experimental'],
+    triggerConditions: [{ requiredKeywords: ['drone', 'minimal', 'ambient', 'texture', 'reverb', 'spacious'], requiredNodes: ['timbre.instruments.synth-pad', 'timbre.effects.reverb'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(50, 5), density: d({ sparse: 0.9, medium: 0.1 }), dynamics: d({ pp: 0.5, p: 0.5 }), space_probability: r(0.4, 0.7, 0.5) },
+  },
+  {
+    id: 'funk-groove',
+    label: 'Funk Groove',
+    genreHints: ['funk', 'groove', 'disco'],
+    triggerConditions: [{ requiredKeywords: ['funk', 'funky', 'groovy', 'groove', 'syncopated', 'slap', 'tight'], requiredNodes: ['harmony.scales.dorian', 'harmony.scales.mixolydian', 'rhythm.groove-feel.syncopated', 'articulation.slap'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(105, 10), groove_strength: r(0.8, 1.0, 0.9), timing_feel: d({ ahead: 0.5, on: 0.5 }), density: d({ medium: 0.6, dense: 0.4 }) },
+  },
+  {
+    id: 'pop-upbeat',
+    label: 'Upbeat Pop',
+    genreHints: ['pop', 'dance pop', 'synth pop'],
+    triggerConditions: [{ requiredKeywords: ['pop', 'upbeat', 'catchy', 'bright', 'happy', 'energetic', 'cheerful', 'bouncy'], requiredNodes: ['harmony.scales.major', 'harmony.scales.lydian'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(118, 10), density: d({ medium: 0.7, dense: 0.3 }), dynamics: d({ mf: 0.5, f: 0.3, mp: 0.2 }) },
+  },
+  {
+    id: 'pop-ballad',
+    label: 'Pop Ballad',
+    genreHints: ['pop', 'ballad', 'power ballad'],
+    triggerConditions: [{ requiredKeywords: ['ballad', 'slow', 'piano', 'gentle', 'soft', 'emotional'], requiredNodes: ['harmony.scales.major', 'harmony.scales.minor', 'timbre.instruments.piano'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(72, 8), density: d({ sparse: 0.5, medium: 0.5 }), dynamics: d({ mp: 0.4, p: 0.3, mf: 0.3 }) },
+  },
+  {
+    id: 'edm-drop',
+    label: 'EDM Drop',
+    genreHints: ['edm', 'dubstep', 'bass music'],
+    triggerConditions: [{ requiredKeywords: ['edm', 'drop', 'build', 'buildup', 'electronic', 'massive', 'bass drop'], requiredNodes: ['harmony.scales.minor', 'harmony.scales.phrygian', 'timbre.instruments.synth-bass', 'structure.sections.drop'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(128, 5), density: r(0.7, 1.0, 0.9), dynamics: d({ ff: 0.7, f: 0.3 }) },
+  },
+  {
+    id: 'edm-house',
+    label: 'House',
+    genreHints: ['house', 'deep house', 'tech house'],
+    triggerConditions: [{ requiredKeywords: ['house', 'four-on-floor', 'electronic', 'club', 'dance'], requiredNodes: ['rhythm.patterns.four-on-floor', 'timbre.instruments.synth-lead'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(124, 3), groove_strength: r(0.7, 0.9, 0.8), density: d({ medium: 0.6, dense: 0.4 }) },
+  },
+  {
+    id: 'edm-dnb',
+    label: 'Drum & Bass',
+    genreHints: ['dnb', 'drum and bass', 'jungle'],
+    triggerConditions: [{ requiredKeywords: ['dnb', 'drum and bass', 'jungle', 'breakbeat', 'fast'], requiredNodes: ['harmony.scales.minor', 'rhythm.patterns.breakbeat', 'rhythm.density.dense'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(174, 4), density: d({ dense: 0.8, medium: 0.2 }), groove_strength: r(0.7, 0.95, 0.85) },
+  },
+  {
+    id: 'hip-hop-boom-bap',
+    label: 'Boom Bap',
+    genreHints: ['hip-hop', 'boom bap', 'old school'],
+    triggerConditions: [{ requiredKeywords: ['hip-hop', 'hip hop', 'boom bap', 'rap', 'sample', 'vinyl'], requiredNodes: ['harmony.scales.minor', 'harmony.scales.dorian', 'rhythm.patterns.boom-bap'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(90, 5), groove_strength: r(0.7, 0.9, 0.8), timing_feel: d({ behind: 0.6, on: 0.4 }) },
+  },
+  {
+    id: 'hip-hop-trap',
+    label: 'Trap',
+    genreHints: ['trap', 'hip-hop', 'drill'],
+    triggerConditions: [{ requiredKeywords: ['trap', '808', 'hi-hat', 'drill', 'dark'], requiredNodes: ['harmony.scales.minor', 'harmony.scales.phrygian', 'timbre.instruments.808'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(140, 10), density: d({ medium: 0.4, dense: 0.4, sparse: 0.2 }), dynamics: d({ f: 0.5, ff: 0.3, mf: 0.2 }) },
+  },
+  {
+    id: 'lo-fi-chill',
+    label: 'Lo-fi Chill',
+    genreHints: ['lo-fi', 'chill', 'study beats'],
+    triggerConditions: [{ requiredKeywords: ['lo-fi', 'lofi', 'chill', 'vinyl', 'tape', 'warm', 'cozy', 'study', 'relax'], requiredNodes: ['harmony.scales.dorian', 'harmony.scales.mixolydian', 'timbre.effects.lo-fi'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(78, 6), timing_feel: d({ behind: 0.8, on: 0.2 }), density: d({ sparse: 0.6, medium: 0.4 }), space_probability: r(0.15, 0.3, 0.25) },
+  },
+  {
+    id: 'classical-romantic',
+    label: 'Romantic Classical',
+    genreHints: ['classical', 'romantic', 'orchestral'],
+    triggerConditions: [{ requiredKeywords: ['classical', 'romantic', 'orchestral', 'strings', 'legato', 'sweeping'], requiredNodes: ['timbre.instruments.strings', 'timbre.instruments.piano', 'articulation.legato'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(85, 15), dynamics: d({ pp: 0.15, p: 0.2, mp: 0.15, mf: 0.15, f: 0.2, ff: 0.15 }), density: d({ medium: 0.5, dense: 0.3, sparse: 0.2 }) },
+  },
+  {
+    id: 'punk-rock',
+    label: 'Punk Rock',
+    genreHints: ['punk', 'punk rock', 'hardcore'],
+    triggerConditions: [{ requiredKeywords: ['punk', 'fast', 'distortion', 'aggressive', 'raw', 'loud', 'power chords', 'angry'], requiredNodes: ['harmony.scales.minor', 'harmony.scales.phrygian', 'timbre.effects.distortion', 'harmony.chords.power-chord'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(175, 15), density: r(0.7, 1.0, 0.85), dynamics: d({ ff: 0.7, f: 0.3 }) },
+  },
+  {
+    id: 'grunge',
+    label: 'Grunge',
+    genreHints: ['grunge', 'alternative', '90s rock'],
+    triggerConditions: [{ requiredKeywords: ['grunge', 'distortion', 'quiet-loud', 'raw', 'angst', 'guitar'], requiredNodes: ['harmony.scales.minor', 'harmony.scales.phrygian', 'timbre.effects.distortion'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(120, 12), dynamics: d({ pp: 0.2, p: 0.1, ff: 0.4, f: 0.3 }), density: d({ medium: 0.4, dense: 0.4, sparse: 0.2 }) },
+  },
+  {
+    id: 'indie-folk',
+    label: 'Indie Folk',
+    genreHints: ['indie', 'folk', 'acoustic'],
+    triggerConditions: [{ requiredKeywords: ['indie', 'folk', 'acoustic', 'fingerpicking', 'gentle', 'organic'], requiredNodes: ['harmony.scales.major', 'harmony.scales.mixolydian', 'timbre.instruments.acoustic-guitar', 'articulation.fingerpicking'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(100, 10), density: d({ sparse: 0.4, medium: 0.5, dense: 0.1 }), dynamics: d({ mp: 0.4, p: 0.3, mf: 0.3 }) },
+  },
+  {
+    id: 'country-traditional',
+    label: 'Country',
+    genreHints: ['country', 'bluegrass', 'americana'],
+    triggerConditions: [{ requiredKeywords: ['country', 'twang', 'fiddle', 'pedal steel', 'honky-tonk'], requiredNodes: ['harmony.scales.major', 'harmony.scales.mixolydian', 'timbre.instruments.acoustic-guitar'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(110, 8), timing_feel: d({ on: 0.7, behind: 0.3 }), density: d({ medium: 0.6, sparse: 0.3, dense: 0.1 }) },
+  },
+  {
+    id: 'reggae',
+    label: 'Reggae',
+    genreHints: ['reggae', 'dub', 'ska'],
+    triggerConditions: [{ requiredKeywords: ['reggae', 'offbeat', 'dub', 'ska', 'island', 'laid-back'], requiredNodes: ['harmony.scales.minor', 'harmony.scales.dorian', 'rhythm.syncopation.offbeat'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(80, 5), timing_feel: d({ behind: 0.7, on: 0.3 }), groove_strength: r(0.7, 0.9, 0.8) },
+  },
+  {
+    id: 'bossa-nova',
+    label: 'Bossa Nova',
+    genreHints: ['bossa nova', 'brazilian', 'mpb'],
+    triggerConditions: [{ requiredKeywords: ['bossa', 'bossa nova', 'brazilian', 'nylon', 'gentle'], requiredNodes: ['harmony.scales.major', 'harmony.scales.lydian', 'timbre.instruments.acoustic-guitar'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(130, 8), swing: r(0.3, 0.6, 0.5), density: d({ sparse: 0.4, medium: 0.6 }), dynamics: d({ mp: 0.4, p: 0.3, mf: 0.3 }) },
+  },
+  {
+    id: 'r-and-b-slow',
+    label: 'Slow R&B',
+    genreHints: ['r&b', 'rnb', 'slow jam'],
+    triggerConditions: [{ requiredKeywords: ['r&b', 'rnb', 'soul', 'smooth', 'slow jam', 'sensual'], requiredNodes: ['harmony.scales.minor', 'harmony.scales.dorian', 'timbre.instruments.synth-pad'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(68, 6), timing_feel: d({ behind: 0.7, on: 0.3 }), groove_strength: r(0.6, 0.8, 0.7), dynamics: d({ mp: 0.4, p: 0.3, mf: 0.3 }) },
+  },
+  {
+    id: 'prog-rock',
+    label: 'Progressive Rock',
+    genreHints: ['prog', 'progressive', 'art rock'],
+    triggerConditions: [{ requiredKeywords: ['prog', 'progressive', 'complex', 'odd meter', 'time signature'], requiredNodes: ['rhythm.time-signatures.5-4', 'rhythm.time-signatures.7-8', 'harmony.scales.dorian', 'harmony.scales.lydian'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(120, 20), density: d({ medium: 0.3, dense: 0.5, sparse: 0.2 }), harmonic_rhythm: d({ fast: 0.4, medium: 0.4, slow: 0.2 }) },
+  },
+  {
+    id: 'post-rock',
+    label: 'Post-Rock',
+    genreHints: ['post-rock', 'atmospheric rock', 'shoegaze'],
+    triggerConditions: [{ requiredKeywords: ['post-rock', 'atmospheric', 'reverb', 'crescendo', 'building', 'wall of sound', 'ethereal'], requiredNodes: ['harmony.scales.minor', 'timbre.effects.reverb', 'timbre.effects.delay', 'dynamics.changes.crescendo'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(90, 10), dynamics: d({ pp: 0.3, p: 0.2, ff: 0.3, f: 0.2 }), space_probability: r(0.1, 0.35, 0.2) },
+  },
+  {
+    id: 'synthwave-retro',
+    label: 'Synthwave/Retrowave',
+    genreHints: ['synthwave', 'retrowave', '80s', 'outrun'],
+    triggerConditions: [{ requiredKeywords: ['synthwave', 'retrowave', '80s', 'neon', 'retro', 'arpeggiated', 'driving'], requiredNodes: ['harmony.scales.minor', 'harmony.scales.dorian', 'timbre.instruments.synth-lead'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(118, 8), density: d({ medium: 0.6, dense: 0.4 }), dynamics: d({ mf: 0.4, f: 0.4, mp: 0.2 }) },
+  },
+  {
+    id: 'latin-salsa',
+    label: 'Latin Salsa',
+    genreHints: ['salsa', 'latin', 'cumbia'],
+    triggerConditions: [{ requiredKeywords: ['salsa', 'latin', 'clave', 'brass', 'percussion', 'cumbia'], requiredNodes: ['harmony.scales.major', 'harmony.scales.mixolydian', 'rhythm.patterns.clave', 'timbre.instruments.brass'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(180, 10), groove_strength: r(0.85, 1.0, 0.95), density: d({ dense: 0.6, medium: 0.4 }) },
+  },
+  {
+    id: 'gospel',
+    label: 'Gospel',
+    genreHints: ['gospel', 'worship', 'spiritual'],
+    triggerConditions: [{ requiredKeywords: ['gospel', 'worship', 'choir', 'organ', 'spiritual', 'praise'], requiredNodes: ['harmony.scales.major', 'harmony.scales.mixolydian', 'timbre.instruments.organ', 'timbre.instruments.choir'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(100, 12), dynamics: d({ mp: 0.2, mf: 0.2, f: 0.3, ff: 0.3 }), harmonic_rhythm: d({ medium: 0.5, fast: 0.3, slow: 0.2 }) },
+  },
+  {
+    id: 'cinematic-epic',
+    label: 'Cinematic Epic',
+    genreHints: ['cinematic', 'film', 'epic', 'trailer'],
+    triggerConditions: [{ requiredKeywords: ['cinematic', 'epic', 'orchestral', 'film', 'dramatic', 'sweeping', 'massive'], requiredNodes: ['harmony.scales.minor', 'timbre.instruments.strings', 'timbre.instruments.brass', 'timbre.instruments.choir'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(90, 15), density: r(0.5, 1.0, 0.8), dynamics: d({ ff: 0.3, f: 0.3, pp: 0.2, p: 0.2 }) },
+  },
+  {
+    id: 'neo-soul',
+    label: 'Neo-Soul',
+    genreHints: ['neo-soul', 'soul', 'erykah badu'],
+    triggerConditions: [{ requiredKeywords: ['neo-soul', 'neo soul', 'soul', 'warm', 'smooth', 'organic', 'groove'], requiredNodes: ['harmony.scales.dorian', 'harmony.scales.mixolydian', 'timbre.instruments.piano', 'timbre.instruments.bass-guitar'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(85, 8), groove_strength: r(0.6, 0.85, 0.75), timing_feel: d({ behind: 0.7, on: 0.3 }), harmonic_rhythm: d({ medium: 0.5, slow: 0.3, fast: 0.2 }) },
+  },
+  {
+    id: 'world-afrobeat',
+    label: 'Afrobeat',
+    genreHints: ['afrobeat', 'afro', 'world'],
+    triggerConditions: [{ requiredKeywords: ['afrobeat', 'afro', 'polyrhythm', 'percussion', 'brass', 'groove'], requiredNodes: ['harmony.scales.dorian', 'harmony.scales.mixolydian', 'rhythm.polyrhythm.2-against-3', 'timbre.instruments.brass'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(115, 8), groove_strength: r(0.85, 1.0, 0.9), density: d({ dense: 0.5, medium: 0.5 }) },
+  },
+  {
+    id: 'video-game-chiptune',
+    label: 'Chiptune/8-bit',
+    genreHints: ['chiptune', '8-bit', 'video game', 'retro'],
+    triggerConditions: [{ requiredKeywords: ['chiptune', '8-bit', 'retro', 'video game', 'pixel', 'bitcrushed'], requiredNodes: ['timbre.effects.bitcrusher', 'harmony.scales.major', 'harmony.scales.minor'], minMatchCount: 2 }],
+    parameterOverrides: { tempo: g(140, 15), density: d({ medium: 0.4, dense: 0.5, sparse: 0.1 }), dynamics: d({ mf: 0.5, f: 0.3, mp: 0.2 }) },
+  },
+];

--- a/src/data/interpretationEngine.ts
+++ b/src/data/interpretationEngine.ts
@@ -1,0 +1,351 @@
+/**
+ * Probabilistic Interpretation Engine for KmiDi Universal Music Input.
+ *
+ * Takes active taxonomy nodes + NLP keywords, resolves context clusters,
+ * merges probability distributions, and samples concrete values.
+ *
+ * All functions are pure — no side effects, runs entirely client-side.
+ */
+
+import type { CompleteSongIntentRequest } from '../types/Intent';
+import type { ParamDistribution } from '../types/Interpretation';
+
+// ─── Types ───────────────────────────────────────
+
+export interface ContextCluster {
+  id: string;
+  label: string;
+  genreHints: string[];
+  triggerKeywords: Set<string>;
+  triggerNodes: Set<string>;
+  minMatchCount: number;
+  parameterOverrides: Record<string, ParamDistribution>;
+}
+
+export interface ScoredCluster {
+  cluster: ContextCluster;
+  score: number;
+  matchedNodes: string[];
+  matchedKeywords: string[];
+}
+
+export interface InterpretationResult {
+  distributions: Record<string, ParamDistribution>;
+  activeClusters: ScoredCluster[];
+  summary: string;
+  confidence: number;
+}
+
+export interface UserPriors {
+  tempoShift?: number;
+  modeWeightAdjustments?: Record<string, number>;
+  preferredDensity?: number;
+}
+
+// ─── Seedable PRNG ──────────────────────────────
+
+function createRng(seed: number): () => number {
+  return function () {
+    seed |= 0;
+    seed = (seed + 0x6d2b79f5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// ─── Cluster Resolution ─────────────────────────
+
+export function resolveContextClusters(
+  activeNodeIds: Set<string>,
+  keywords: string[],
+  clusters: ContextCluster[],
+): ScoredCluster[] {
+  const keywordSet = new Set(keywords.map((k) => k.toLowerCase()));
+  const scored: ScoredCluster[] = [];
+
+  for (const cluster of clusters) {
+    const matchedNodes: string[] = [];
+    const matchedKeywords: string[] = [];
+
+    for (const nodeId of cluster.triggerNodes) {
+      if (activeNodeIds.has(nodeId)) matchedNodes.push(nodeId);
+    }
+    for (const kw of cluster.triggerKeywords) {
+      if (keywordSet.has(kw)) matchedKeywords.push(kw);
+    }
+
+    const totalMatches = matchedNodes.length + matchedKeywords.length;
+    if (totalMatches >= cluster.minMatchCount) {
+      const score = Math.min(1.0, totalMatches / (cluster.minMatchCount + 1));
+      scored.push({ cluster, score, matchedNodes, matchedKeywords });
+    }
+  }
+
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, 5);
+}
+
+// ─── Distribution Merging ───────────────────────
+
+function blendGaussian(
+  a: ParamDistribution,
+  b: ParamDistribution,
+  bWeight: number,
+): ParamDistribution {
+  const aWeight = 1 - bWeight;
+  return {
+    type: 'gaussian',
+    center: (a.center ?? 0) * aWeight + (b.center ?? 0) * bWeight,
+    spread: Math.max(a.spread ?? 0, b.spread ?? 0),
+  };
+}
+
+function blendDiscrete(
+  a: ParamDistribution,
+  b: ParamDistribution,
+  bWeight: number,
+): ParamDistribution {
+  const aWeight = 1 - bWeight;
+  const merged: Record<string, number> = {};
+  const allKeys = new Set([
+    ...Object.keys(a.weights ?? {}),
+    ...Object.keys(b.weights ?? {}),
+  ]);
+  for (const k of allKeys) {
+    const av = (a.weights ?? {})[k] ?? 0;
+    const bv = (b.weights ?? {})[k] ?? 0;
+    merged[k] = av * aWeight + bv * bWeight;
+  }
+  const total = Object.values(merged).reduce((s, v) => s + v, 0);
+  if (total > 0) {
+    for (const k of Object.keys(merged)) merged[k] /= total;
+  }
+  return { type: 'discrete', weights: merged };
+}
+
+function blendRange(
+  a: ParamDistribution,
+  b: ParamDistribution,
+  bWeight: number,
+): ParamDistribution {
+  const aWeight = 1 - bWeight;
+  return {
+    type: 'range',
+    min: (a.min ?? 0) * aWeight + (b.min ?? 0) * bWeight,
+    max: (a.max ?? 1) * aWeight + (b.max ?? 1) * bWeight,
+    bias: (a.bias ?? 0.5) * aWeight + (b.bias ?? 0.5) * bWeight,
+  };
+}
+
+function blendDistributions(
+  a: ParamDistribution,
+  b: ParamDistribution,
+  bWeight: number,
+): ParamDistribution {
+  if (a.type === b.type) {
+    if (a.type === 'gaussian') return blendGaussian(a, b, bWeight);
+    if (a.type === 'discrete') return blendDiscrete(a, b, bWeight);
+    if (a.type === 'range') return blendRange(a, b, bWeight);
+  }
+  return bWeight > 0.5 ? b : a;
+}
+
+export function mergeDistributions(
+  contributions: Record<string, ParamDistribution>[],
+  clusterOverrides: Record<string, ParamDistribution>[],
+  clusterWeights: number[],
+): Record<string, ParamDistribution> {
+  const merged: Record<string, ParamDistribution> = {};
+
+  // Merge node contributions (equal weight)
+  for (const contrib of contributions) {
+    for (const [param, dist] of Object.entries(contrib)) {
+      if (!merged[param]) {
+        merged[param] = dist;
+      } else {
+        merged[param] = blendDistributions(merged[param], dist, 0.5);
+      }
+    }
+  }
+
+  // Apply cluster overrides weighted by score
+  for (let i = 0; i < clusterOverrides.length; i++) {
+    const weight = clusterWeights[i] ?? 0.5;
+    for (const [param, dist] of Object.entries(clusterOverrides[i])) {
+      if (!merged[param]) {
+        merged[param] = dist;
+      } else {
+        merged[param] = blendDistributions(merged[param], dist, weight);
+      }
+    }
+  }
+
+  return merged;
+}
+
+// ─── Interpret ──────────────────────────────────
+
+export function interpret(
+  activeNodeIds: Set<string>,
+  keywords: string[],
+  clusters: ContextCluster[],
+  pinnedParams: Map<string, unknown>,
+  interpretiveLevel: number,
+  userPriors?: UserPriors,
+): InterpretationResult {
+  // 1. Resolve clusters
+  const scoredClusters = resolveContextClusters(activeNodeIds, keywords, clusters);
+
+  // 2. Merge cluster overrides
+  const overrides = scoredClusters.map((sc) => sc.cluster.parameterOverrides);
+  const weights = scoredClusters.map((sc) => sc.score);
+  const distributions = mergeDistributions([], overrides, weights);
+
+  // 3. Apply interpretive level (scale spreads)
+  const spreadScale = 0.1 + interpretiveLevel * 0.9;
+  for (const [param, dist] of Object.entries(distributions)) {
+    if (dist.type === 'gaussian' && dist.spread !== undefined) {
+      distributions[param] = { ...dist, spread: dist.spread * spreadScale };
+    }
+  }
+
+  // 4. Apply pinned params
+  for (const [param, value] of pinnedParams) {
+    if (typeof value === 'number') {
+      distributions[param] = { type: 'gaussian', center: value, spread: 0 };
+    }
+  }
+
+  // 5. Apply user priors
+  if (userPriors?.tempoShift && distributions.tempo?.center !== undefined) {
+    distributions.tempo = {
+      ...distributions.tempo,
+      center: distributions.tempo.center + userPriors.tempoShift,
+    };
+  }
+
+  // 6. Build summary
+  const summary = generateSummary(distributions, scoredClusters);
+
+  // 7. Confidence
+  const confidence =
+    scoredClusters.length > 0
+      ? scoredClusters.reduce((s, c) => s + c.score, 0) / scoredClusters.length
+      : 0.3;
+
+  return { distributions, activeClusters: scoredClusters, summary, confidence };
+}
+
+// ─── Sample ─────────────────────────────────────
+
+export function sample(
+  result: InterpretationResult,
+  seed?: number,
+): CompleteSongIntentRequest {
+  const rng = createRng(seed ?? Date.now());
+
+  const sampleGaussian = (dist: ParamDistribution): number => {
+    const center = dist.center ?? 120;
+    const spread = dist.spread ?? 10;
+    // Box-Muller transform
+    const u1 = rng();
+    const u2 = rng();
+    const z = Math.sqrt(-2 * Math.log(Math.max(0.0001, u1))) * Math.cos(2 * Math.PI * u2);
+    return center + z * spread;
+  };
+
+  const sampleDiscrete = (dist: ParamDistribution): string => {
+    const weights = dist.weights ?? {};
+    const entries = Object.entries(weights);
+    if (entries.length === 0) return 'major';
+    const total = entries.reduce((s, [, w]) => s + w, 0);
+    let r = rng() * total;
+    for (const [key, weight] of entries) {
+      r -= weight;
+      if (r <= 0) return key;
+    }
+    return entries[entries.length - 1][0];
+  };
+
+  const sampleRange = (dist: ParamDistribution): number => {
+    const min = dist.min ?? 0;
+    const max = dist.max ?? 1;
+    const bias = dist.bias ?? (min + max) / 2;
+    // Bias toward the bias point
+    const r = rng();
+    const biasNorm = (bias - min) / (max - min || 1);
+    const skewed = Math.pow(r, 1 / (biasNorm + 0.5));
+    return min + skewed * (max - min);
+  };
+
+  // Sample tempo
+  const tempo = result.distributions.tempo
+    ? Math.round(Math.max(40, Math.min(300, sampleGaussian(result.distributions.tempo))))
+    : 120;
+
+  // Sample mode
+  const mode = result.distributions.mode_weights
+    ? sampleDiscrete(result.distributions.mode_weights)
+    : 'major';
+
+  // Sample key
+  const KEY_DEFAULT: ParamDistribution = {
+    type: 'discrete',
+    weights: { C: 0.18, G: 0.14, D: 0.12, A: 0.10, E: 0.08, F: 0.10, Bb: 0.08, Eb: 0.06, Ab: 0.05, B: 0.04, Db: 0.03, Gb: 0.02 },
+  };
+  const key = result.distributions.key_weights
+    ? sampleDiscrete(result.distributions.key_weights)
+    : sampleDiscrete(KEY_DEFAULT);
+
+  // Sample groove feel
+  const grooveFeel = result.distributions.groove_feel
+    ? sampleDiscrete(result.distributions.groove_feel)
+    : 'Straight/Driving';
+
+  // Top cluster label as genre
+  const genre = result.activeClusters[0]?.cluster.label ?? '';
+
+  return {
+    core_desire: '',
+    mood_primary: genre,
+    genre,
+    tempo,
+    key_mode: `${key} ${mode}`,
+    structure: [
+      { name: 'intro', bars: 4, repetitions: 1 },
+      { name: 'verse', bars: 8, repetitions: 2 },
+      { name: 'chorus', bars: 8, repetitions: 1 },
+    ],
+    instruments: [{ instrument: 'piano', techniques: [] }],
+    groove_feel: grooveFeel,
+    narrative_arc: 'Climb-to-Climax',
+  };
+}
+
+// ─── Summary ────────────────────────────────────
+
+export function generateSummary(
+  distributions: Record<string, ParamDistribution>,
+  clusters: ScoredCluster[],
+): string {
+  const parts: string[] = [];
+
+  if (clusters[0]) {
+    parts.push(clusters[0].cluster.label);
+  }
+
+  const modeWeights = distributions.mode_weights?.weights;
+  if (modeWeights) {
+    const top = Object.entries(modeWeights).sort(([, a], [, b]) => b - a)[0];
+    if (top) parts.push(`${top[0]} ${Math.round(top[1] * 100)}%`);
+  }
+
+  const tempo = distributions.tempo;
+  if (tempo?.center !== undefined) {
+    const spread = tempo.spread ?? 10;
+    parts.push(`~${Math.round(tempo.center - spread)}–${Math.round(tempo.center + spread)} BPM`);
+  }
+
+  return parts.join(' · ');
+}

--- a/src/data/taxonomyTree.ts
+++ b/src/data/taxonomyTree.ts
@@ -1,0 +1,421 @@
+/**
+ * Complete Musical Command Taxonomy
+ *
+ * Every possible musical command/technique organized as a browseable tree.
+ * Each leaf node contributes probability distributions (not fixed values)
+ * and declares which context clusters it participates in.
+ */
+
+import type { ParamDistribution } from '../types/Interpretation';
+
+export interface TaxonomyNode {
+  id: string;
+  label: string;
+  labelKey?: string;
+  children?: TaxonomyNode[];
+  paramContributions?: Record<string, ParamDistribution>;
+  clusterMemberships?: string[];
+  keywords: string[];
+  description?: string;
+}
+
+// Shorthand helpers
+const dw = (weights: Record<string, number>): ParamDistribution => ({ type: 'discrete', weights });
+const rn = (min: number, max: number, bias: number): ParamDistribution => ({ type: 'range', min, max, bias });
+
+export const TAXONOMY_TREE: TaxonomyNode[] = [
+  // ═══ 1. HARMONY ═══
+  {
+    id: 'harmony', label: 'Harmony', keywords: ['harmony', 'chords', 'keys', 'tonality'],
+    children: [
+      {
+        id: 'harmony.keys', label: 'Keys', keywords: ['key', 'root note', 'tonic'],
+        children: ['C', 'C#', 'Db', 'D', 'D#', 'Eb', 'E', 'F', 'F#', 'Gb', 'G', 'G#', 'Ab', 'A', 'A#', 'Bb', 'B'].map(k => ({
+          id: `harmony.keys.${k.replace('#', 'sharp').replace('b', 'flat').toLowerCase()}`,
+          label: k, keywords: [k.toLowerCase(), `key of ${k.toLowerCase()}`],
+          paramContributions: { key: dw({ [k]: 1.0 }) },
+        })),
+      },
+      {
+        id: 'harmony.scales', label: 'Scales & Modes', keywords: ['scales', 'modes'],
+        children: [
+          { id: 'harmony.scales.major', label: 'Major (Ionian)', keywords: ['major', 'ionian', 'happy', 'bright'], paramContributions: { mode_weights: dw({ major: 0.85, lydian: 0.1, mixolydian: 0.05 }) }, clusterMemberships: ['pop-upbeat', 'pop-ballad', 'gospel', 'country-traditional', 'bossa-nova'] },
+          { id: 'harmony.scales.minor', label: 'Minor (Aeolian)', keywords: ['minor', 'aeolian', 'sad', 'dark', 'natural minor'], paramContributions: { mode_weights: dw({ minor: 0.85, dorian: 0.1, phrygian: 0.05 }) }, clusterMemberships: ['metal-shred', 'punk-rock', 'grunge', 'edm-drop', 'hip-hop-trap', 'post-rock', 'cinematic-epic'] },
+          { id: 'harmony.scales.dorian', label: 'Dorian', keywords: ['dorian', 'jazzy', 'soulful', 'minor but bright'], paramContributions: { mode_weights: dw({ dorian: 0.85, minor: 0.1, mixolydian: 0.05 }) }, clusterMemberships: ['metal-shred', 'blues-slow', 'jazz-modal', 'funk-groove', 'lo-fi-chill', 'neo-soul', 'synthwave-retro', 'reggae', 'world-afrobeat'] },
+          { id: 'harmony.scales.phrygian', label: 'Phrygian', keywords: ['phrygian', 'spanish', 'metal', 'exotic', 'dark'], paramContributions: { mode_weights: dw({ phrygian: 0.85, minor: 0.1, locrian: 0.05 }) }, clusterMemberships: ['metal-shred', 'punk-rock', 'edm-drop', 'hip-hop-trap'] },
+          { id: 'harmony.scales.lydian', label: 'Lydian', keywords: ['lydian', 'dreamy', 'bright', 'floating', 'ethereal'], paramContributions: { mode_weights: dw({ lydian: 0.85, major: 0.1, mixolydian: 0.05 }) }, clusterMemberships: ['ambient-pad', 'jazz-modal', 'bossa-nova', 'prog-rock'] },
+          { id: 'harmony.scales.mixolydian', label: 'Mixolydian', keywords: ['mixolydian', 'bluesy', 'dominant', 'rock'], paramContributions: { mode_weights: dw({ mixolydian: 0.85, major: 0.1, dorian: 0.05 }) }, clusterMemberships: ['blues-chicago', 'funk-groove', 'country-traditional', 'gospel', 'neo-soul', 'world-afrobeat'] },
+          { id: 'harmony.scales.locrian', label: 'Locrian', keywords: ['locrian', 'diminished', 'unstable', 'dissonant'], paramContributions: { mode_weights: dw({ locrian: 0.85, phrygian: 0.15 }) }, clusterMemberships: ['metal-shred'] },
+          { id: 'harmony.scales.harmonic-minor', label: 'Harmonic Minor', keywords: ['harmonic minor', 'classical', 'middle eastern'], paramContributions: { mode_weights: dw({ harmonic_minor: 0.85, minor: 0.15 }) }, clusterMemberships: ['metal-shred', 'classical-romantic'] },
+          { id: 'harmony.scales.melodic-minor', label: 'Melodic Minor', keywords: ['melodic minor', 'jazz minor'], paramContributions: { mode_weights: dw({ melodic_minor: 0.85, minor: 0.15 }) }, clusterMemberships: ['jazz-modal', 'jazz-bebop'] },
+          { id: 'harmony.scales.pentatonic-major', label: 'Pentatonic Major', keywords: ['pentatonic major', 'country', 'folk', 'simple'], paramContributions: { mode_weights: dw({ pentatonic_major: 0.85, major: 0.15 }) }, clusterMemberships: ['country-traditional', 'pop-upbeat', 'indie-folk'] },
+          { id: 'harmony.scales.pentatonic-minor', label: 'Pentatonic Minor', keywords: ['pentatonic', 'pentatonic minor', 'blues', 'rock'], paramContributions: { mode_weights: dw({ pentatonic_minor: 0.85, minor: 0.15 }) }, clusterMemberships: ['blues-slow', 'blues-chicago', 'hip-hop-boom-bap'] },
+          { id: 'harmony.scales.blues', label: 'Blues Scale', keywords: ['blues scale', 'bluesy', 'blue note'], paramContributions: { mode_weights: dw({ blues: 0.85, pentatonic_minor: 0.15 }) }, clusterMemberships: ['blues-slow', 'blues-chicago'] },
+          { id: 'harmony.scales.whole-tone', label: 'Whole Tone', keywords: ['whole tone', 'augmented', 'dreamy', 'impressionist'], paramContributions: { mode_weights: dw({ whole_tone: 0.9, lydian: 0.1 }) }, clusterMemberships: ['ambient-pad'] },
+          { id: 'harmony.scales.chromatic', label: 'Chromatic', keywords: ['chromatic', 'all notes', 'atonal'], paramContributions: { mode_weights: dw({ chromatic: 1.0 }) }, clusterMemberships: ['jazz-bebop'] },
+          { id: 'harmony.scales.diminished', label: 'Diminished', keywords: ['diminished', 'octatonic', 'symmetric'], paramContributions: { mode_weights: dw({ diminished: 0.9, locrian: 0.1 }) }, clusterMemberships: ['jazz-bebop', 'metal-shred'] },
+        ],
+      },
+      {
+        id: 'harmony.chords', label: 'Chords', keywords: ['chords', 'voicings'],
+        children: [
+          { id: 'harmony.chords.major-triad', label: 'Major Triad', keywords: ['major chord', 'major triad'], paramContributions: { harmonic_tension: rn(0, 0.2, 0.1) }, clusterMemberships: ['pop-upbeat', 'country-traditional'] },
+          { id: 'harmony.chords.minor-triad', label: 'Minor Triad', keywords: ['minor chord', 'minor triad'], paramContributions: { harmonic_tension: rn(0.1, 0.3, 0.2) }, clusterMemberships: ['pop-ballad', 'indie-folk'] },
+          { id: 'harmony.chords.dim-triad', label: 'Diminished Triad', keywords: ['diminished', 'dim'], paramContributions: { harmonic_tension: rn(0.5, 0.8, 0.65) }, clusterMemberships: ['classical-romantic'] },
+          { id: 'harmony.chords.aug-triad', label: 'Augmented Triad', keywords: ['augmented', 'aug'], paramContributions: { harmonic_tension: rn(0.4, 0.7, 0.55) }, clusterMemberships: ['jazz-modal'] },
+          { id: 'harmony.chords.maj7', label: 'Major 7th', keywords: ['maj7', 'major seventh', 'dreamy'], paramContributions: { harmonic_tension: rn(0.1, 0.3, 0.2) }, clusterMemberships: ['jazz-modal', 'bossa-nova', 'neo-soul'] },
+          { id: 'harmony.chords.min7', label: 'Minor 7th', keywords: ['min7', 'minor seventh'], paramContributions: { harmonic_tension: rn(0.15, 0.35, 0.25) }, clusterMemberships: ['jazz-modal', 'neo-soul', 'lo-fi-chill'] },
+          { id: 'harmony.chords.dom7', label: 'Dominant 7th', keywords: ['dom7', 'dominant seventh', '7th'], paramContributions: { harmonic_tension: rn(0.2, 0.5, 0.35) }, clusterMemberships: ['blues-slow', 'blues-chicago', 'funk-groove'] },
+          { id: 'harmony.chords.sus2', label: 'Sus2', keywords: ['sus2', 'suspended second', 'open'], paramContributions: { harmonic_tension: rn(0.1, 0.25, 0.15) }, clusterMemberships: ['ambient-pad', 'post-rock'] },
+          { id: 'harmony.chords.sus4', label: 'Sus4', keywords: ['sus4', 'suspended fourth'], paramContributions: { harmonic_tension: rn(0.15, 0.3, 0.2) }, clusterMemberships: ['pop-upbeat', 'post-rock'] },
+          { id: 'harmony.chords.power-chord', label: 'Power Chord', keywords: ['power chord', 'fifth', 'rock'], paramContributions: { harmonic_tension: rn(0, 0.15, 0.05) }, clusterMemberships: ['punk-rock', 'metal-shred', 'grunge'] },
+          { id: 'harmony.chords.dom9', label: 'Dominant 9th', keywords: ['dom9', '9th', 'funk chord'], paramContributions: { harmonic_tension: rn(0.25, 0.5, 0.35) }, clusterMemberships: ['funk-groove', 'neo-soul'] },
+          { id: 'harmony.chords.dom7alt', label: 'Altered Dominant', keywords: ['alt', 'altered', 'jazz altered'], paramContributions: { harmonic_tension: rn(0.5, 0.9, 0.7) }, clusterMemberships: ['jazz-bebop', 'jazz-modal'] },
+        ],
+      },
+      {
+        id: 'harmony.progressions', label: 'Progressions', keywords: ['progression', 'chord progression'],
+        children: [
+          { id: 'harmony.progressions.I-V-vi-IV', label: 'I-V-vi-IV', keywords: ['pop progression', 'four chord', 'axis'], paramContributions: { mode_weights: dw({ major: 0.9, mixolydian: 0.1 }) }, clusterMemberships: ['pop-upbeat'] },
+          { id: 'harmony.progressions.ii-V-I', label: 'ii-V-I', keywords: ['two five one', 'jazz standard'], paramContributions: { mode_weights: dw({ major: 0.5, dorian: 0.3, mixolydian: 0.2 }) }, clusterMemberships: ['jazz-modal', 'jazz-bebop', 'bossa-nova'] },
+          { id: 'harmony.progressions.twelve-bar-blues', label: '12-Bar Blues', keywords: ['twelve bar', 'blues form', 'I-IV-V'], paramContributions: { mode_weights: dw({ mixolydian: 0.5, blues: 0.3, dorian: 0.2 }) }, clusterMemberships: ['blues-slow', 'blues-chicago'] },
+          { id: 'harmony.progressions.i-VII-VI-VII', label: 'i-VII-VI-VII', keywords: ['dorian drift', 'modal'], paramContributions: { mode_weights: dw({ dorian: 0.8, minor: 0.2 }) }, clusterMemberships: ['jazz-modal', 'lo-fi-chill'] },
+        ],
+      },
+      {
+        id: 'harmony.techniques', label: 'Techniques', keywords: ['harmony technique'],
+        children: [
+          { id: 'harmony.techniques.modal-interchange', label: 'Modal Interchange', keywords: ['modal interchange', 'borrowed chord', 'parallel key'], paramContributions: { harmonic_tension: rn(0.3, 0.6, 0.45) }, clusterMemberships: ['prog-rock', 'neo-soul'] },
+          { id: 'harmony.techniques.tritone-sub', label: 'Tritone Substitution', keywords: ['tritone sub', 'tritone substitution'], paramContributions: { harmonic_tension: rn(0.4, 0.7, 0.55) }, clusterMemberships: ['jazz-bebop', 'jazz-modal'] },
+          { id: 'harmony.techniques.pedal-point', label: 'Pedal Point', keywords: ['pedal point', 'drone', 'sustained bass'], paramContributions: { harmonic_tension: rn(0.1, 0.4, 0.2) }, clusterMemberships: ['ambient-drone', 'post-rock', 'cinematic-epic'] },
+          { id: 'harmony.techniques.voice-leading', label: 'Voice Leading', keywords: ['voice leading', 'smooth motion', 'stepwise'], paramContributions: {}, clusterMemberships: ['classical-romantic', 'jazz-modal'] },
+        ],
+      },
+    ],
+  },
+
+  // ═══ 2. MELODY ═══
+  {
+    id: 'melody', label: 'Melody', keywords: ['melody', 'tune', 'melodic'],
+    children: [
+      {
+        id: 'melody.contour', label: 'Contour', keywords: ['contour', 'shape', 'direction'],
+        children: [
+          { id: 'melody.contour.ascending', label: 'Ascending', keywords: ['ascending', 'rising', 'upward'], paramContributions: { melodic_activity: rn(0.4, 0.7, 0.55) }, clusterMemberships: ['cinematic-epic', 'edm-drop'] },
+          { id: 'melody.contour.descending', label: 'Descending', keywords: ['descending', 'falling', 'downward'], paramContributions: { melodic_activity: rn(0.3, 0.6, 0.45) }, clusterMemberships: ['blues-slow', 'pop-ballad'] },
+          { id: 'melody.contour.arch', label: 'Arch', keywords: ['arch', 'hill', 'up and down'], paramContributions: { melodic_activity: rn(0.4, 0.7, 0.55) }, clusterMemberships: ['pop-upbeat', 'classical-romantic'] },
+          { id: 'melody.contour.wave', label: 'Wave', keywords: ['wave', 'undulating', 'arpeggio'], paramContributions: { melodic_activity: rn(0.5, 0.8, 0.65) }, clusterMemberships: ['synthwave-retro', 'ambient-pad'] },
+          { id: 'melody.contour.static', label: 'Static', keywords: ['static', 'monotone', 'repeated note'], paramContributions: { melodic_activity: rn(0, 0.2, 0.1) }, clusterMemberships: ['ambient-drone', 'hip-hop-trap'] },
+        ],
+      },
+      {
+        id: 'melody.activity', label: 'Activity', keywords: ['activity', 'note density'],
+        children: [
+          { id: 'melody.activity.sparse', label: 'Sparse', keywords: ['sparse melody', 'few notes', 'space'], paramContributions: { melodic_activity: rn(0, 0.25, 0.1) }, clusterMemberships: ['ambient-pad', 'ambient-drone'] },
+          { id: 'melody.activity.moderate', label: 'Moderate', keywords: ['moderate melody', 'balanced'], paramContributions: { melodic_activity: rn(0.3, 0.6, 0.45) }, clusterMemberships: ['pop-upbeat', 'indie-folk'] },
+          { id: 'melody.activity.active', label: 'Active', keywords: ['active melody', 'busy', 'moving'], paramContributions: { melodic_activity: rn(0.6, 0.85, 0.7) }, clusterMemberships: ['jazz-bebop', 'funk-groove'] },
+          { id: 'melody.activity.virtuosic', label: 'Virtuosic', keywords: ['virtuosic', 'shredding', 'rapid', 'technical'], paramContributions: { melodic_activity: rn(0.8, 1.0, 0.9) }, clusterMemberships: ['metal-shred', 'jazz-bebop'] },
+        ],
+      },
+      {
+        id: 'melody.ornamentation', label: 'Ornamentation', keywords: ['ornament', 'embellishment'],
+        children: [
+          { id: 'melody.ornamentation.trill', label: 'Trill', keywords: ['trill', 'rapid alternation'], paramContributions: {}, clusterMemberships: ['classical-romantic'] },
+          { id: 'melody.ornamentation.grace-note', label: 'Grace Note', keywords: ['grace note', 'appoggiatura', 'acciaccatura'], paramContributions: {}, clusterMemberships: ['classical-romantic', 'jazz-bebop'] },
+          { id: 'melody.ornamentation.bend', label: 'Bend', keywords: ['bend', 'string bend', 'pitch bend'], paramContributions: {}, clusterMemberships: ['blues-slow', 'blues-chicago', 'metal-shred'] },
+          { id: 'melody.ornamentation.slide', label: 'Slide', keywords: ['slide', 'glide', 'portamento'], paramContributions: {}, clusterMemberships: ['blues-slow', 'country-traditional'] },
+        ],
+      },
+    ],
+  },
+
+  // ═══ 3. RHYTHM ═══
+  {
+    id: 'rhythm', label: 'Rhythm', keywords: ['rhythm', 'beat', 'groove', 'time'],
+    children: [
+      {
+        id: 'rhythm.time-signatures', label: 'Time Signatures', keywords: ['time signature', 'meter'],
+        children: [
+          { id: 'rhythm.time-signatures.4-4', label: '4/4', keywords: ['four four', 'common time'], paramContributions: {}, clusterMemberships: ['pop-upbeat', 'rock', 'edm-house'] },
+          { id: 'rhythm.time-signatures.3-4', label: '3/4 (Waltz)', keywords: ['three four', 'waltz', 'triple'], paramContributions: {}, clusterMemberships: ['classical-romantic'] },
+          { id: 'rhythm.time-signatures.6-8', label: '6/8', keywords: ['six eight', 'compound'], paramContributions: {}, clusterMemberships: ['blues-slow', 'gospel'] },
+          { id: 'rhythm.time-signatures.5-4', label: '5/4', keywords: ['five four', 'odd meter', 'take five'], paramContributions: {}, clusterMemberships: ['prog-rock', 'jazz-modal'] },
+          { id: 'rhythm.time-signatures.7-8', label: '7/8', keywords: ['seven eight', 'odd meter', 'prog'], paramContributions: {}, clusterMemberships: ['prog-rock'] },
+        ],
+      },
+      {
+        id: 'rhythm.patterns', label: 'Patterns', keywords: ['pattern', 'beat pattern'],
+        children: [
+          { id: 'rhythm.patterns.four-on-floor', label: 'Four on the Floor', keywords: ['four on floor', 'kick every beat', 'house beat'], paramContributions: { groove_strength: rn(0.7, 0.9, 0.8) }, clusterMemberships: ['edm-house', 'edm-drop'] },
+          { id: 'rhythm.patterns.backbeat', label: 'Backbeat', keywords: ['backbeat', 'snare on 2 and 4', 'rock beat'], paramContributions: { groove_strength: rn(0.5, 0.8, 0.65) }, clusterMemberships: ['pop-upbeat', 'punk-rock', 'grunge'] },
+          { id: 'rhythm.patterns.shuffle', label: 'Shuffle', keywords: ['shuffle', 'triplet feel', 'bouncy'], paramContributions: { swing: rn(0.4, 0.7, 0.55) }, clusterMemberships: ['blues-chicago', 'country-traditional'] },
+          { id: 'rhythm.patterns.clave', label: 'Clave', keywords: ['clave', 'son clave', 'latin rhythm'], paramContributions: { groove_strength: rn(0.8, 1.0, 0.9) }, clusterMemberships: ['latin-salsa', 'bossa-nova'] },
+          { id: 'rhythm.patterns.breakbeat', label: 'Breakbeat', keywords: ['breakbeat', 'break', 'amen'], paramContributions: { groove_strength: rn(0.7, 0.95, 0.85) }, clusterMemberships: ['edm-dnb', 'hip-hop-boom-bap'] },
+          { id: 'rhythm.patterns.boom-bap', label: 'Boom Bap', keywords: ['boom bap', 'hip-hop beat', 'old school'], paramContributions: { groove_strength: rn(0.7, 0.9, 0.8) }, clusterMemberships: ['hip-hop-boom-bap'] },
+        ],
+      },
+      {
+        id: 'rhythm.syncopation', label: 'Syncopation', keywords: ['syncopation', 'offbeat'],
+        children: [
+          { id: 'rhythm.syncopation.none', label: 'None', keywords: ['no syncopation', 'on-beat', 'straight'], paramContributions: { groove_strength: rn(0, 0.3, 0.15) }, clusterMemberships: ['pop-upbeat'] },
+          { id: 'rhythm.syncopation.light', label: 'Light', keywords: ['light syncopation', 'subtle'], paramContributions: { groove_strength: rn(0.2, 0.5, 0.35) }, clusterMemberships: ['bossa-nova', 'indie-folk'] },
+          { id: 'rhythm.syncopation.heavy', label: 'Heavy', keywords: ['heavy syncopation', 'funky'], paramContributions: { groove_strength: rn(0.6, 0.9, 0.75) }, clusterMemberships: ['funk-groove', 'latin-salsa'] },
+          { id: 'rhythm.syncopation.offbeat', label: 'Offbeat', keywords: ['offbeat', 'reggae', 'ska'], paramContributions: { groove_strength: rn(0.6, 0.85, 0.7) }, clusterMemberships: ['reggae'] },
+        ],
+      },
+      {
+        id: 'rhythm.density', label: 'Density', keywords: ['density', 'busy', 'sparse'],
+        children: [
+          { id: 'rhythm.density.sparse', label: 'Sparse', keywords: ['sparse', 'minimal', 'space', 'slow'], paramContributions: { density: dw({ sparse: 0.85, medium: 0.15 }) }, clusterMemberships: ['ambient-pad', 'ambient-drone', 'blues-slow', 'jazz-ballad'] },
+          { id: 'rhythm.density.medium', label: 'Medium', keywords: ['medium density', 'balanced', 'moderate'], paramContributions: { density: dw({ medium: 0.8, sparse: 0.1, dense: 0.1 }) }, clusterMemberships: ['pop-upbeat', 'indie-folk', 'neo-soul'] },
+          { id: 'rhythm.density.dense', label: 'Dense', keywords: ['dense', 'busy', 'fast', 'complex', 'rapid'], paramContributions: { density: dw({ dense: 0.85, medium: 0.15 }) }, clusterMemberships: ['metal-shred', 'jazz-bebop', 'edm-dnb', 'punk-rock'] },
+        ],
+      },
+      {
+        id: 'rhythm.swing', label: 'Swing', keywords: ['swing', 'shuffle'],
+        children: [
+          { id: 'rhythm.swing.straight', label: 'Straight', keywords: ['straight', 'no swing', 'even'], paramContributions: { swing: rn(0, 0.1, 0.05) }, clusterMemberships: ['pop-upbeat', 'edm-house', 'punk-rock', 'metal-shred'] },
+          { id: 'rhythm.swing.light-swing', label: 'Light Swing', keywords: ['light swing', 'gentle swing', 'lilt'], paramContributions: { swing: rn(0.2, 0.45, 0.3) }, clusterMemberships: ['bossa-nova', 'lo-fi-chill', 'neo-soul'] },
+          { id: 'rhythm.swing.heavy-swing', label: 'Heavy Swing', keywords: ['heavy swing', 'hard swing', 'jazz swing'], paramContributions: { swing: rn(0.5, 0.85, 0.7) }, clusterMemberships: ['jazz-modal', 'jazz-bebop', 'blues-chicago'] },
+        ],
+      },
+      {
+        id: 'rhythm.groove-feel', label: 'Groove Feel', keywords: ['groove', 'feel'],
+        children: [
+          { id: 'rhythm.groove-feel.straight-driving', label: 'Straight/Driving', keywords: ['straight', 'driving', 'tight', 'rigid'], paramContributions: { groove_feel: dw({ 'Straight/Driving': 1.0 }), timing_feel: dw({ on: 0.7, ahead: 0.3 }) }, clusterMemberships: ['metal-shred', 'punk-rock', 'edm-house'] },
+          { id: 'rhythm.groove-feel.laid-back', label: 'Laid Back', keywords: ['laid-back', 'relaxed', 'chill', 'behind the beat'], paramContributions: { groove_feel: dw({ 'Laid Back': 1.0 }), timing_feel: dw({ behind: 0.8, on: 0.2 }) }, clusterMemberships: ['lo-fi-chill', 'reggae', 'neo-soul', 'r-and-b-slow'] },
+          { id: 'rhythm.groove-feel.swung', label: 'Swung', keywords: ['swing', 'swung', 'shuffle', 'bouncy'], paramContributions: { groove_feel: dw({ Swung: 1.0 }), swing: rn(0.4, 0.8, 0.6) }, clusterMemberships: ['jazz-modal', 'blues-chicago'] },
+          { id: 'rhythm.groove-feel.syncopated', label: 'Syncopated', keywords: ['syncopated', 'funky', 'offbeat'], paramContributions: { groove_feel: dw({ Syncopated: 1.0 }), groove_strength: rn(0.7, 1.0, 0.85) }, clusterMemberships: ['funk-groove', 'latin-salsa', 'world-afrobeat'] },
+          { id: 'rhythm.groove-feel.rubato', label: 'Rubato/Free', keywords: ['rubato', 'free tempo', 'expressive'], paramContributions: { groove_feel: dw({ 'Rubato/Free': 1.0 }) }, clusterMemberships: ['classical-romantic', 'jazz-ballad'] },
+          { id: 'rhythm.groove-feel.mechanical', label: 'Mechanical', keywords: ['mechanical', 'robotic', 'quantized', 'precise'], paramContributions: { groove_feel: dw({ Mechanical: 1.0 }), timing_feel: dw({ on: 0.9, ahead: 0.1 }) }, clusterMemberships: ['edm-house', 'video-game-chiptune'] },
+          { id: 'rhythm.groove-feel.organic', label: 'Organic/Breathing', keywords: ['organic', 'human', 'natural', 'breathing'], paramContributions: { groove_feel: dw({ 'Organic/Breathing': 1.0 }) }, clusterMemberships: ['indie-folk', 'neo-soul', 'gospel'] },
+          { id: 'rhythm.groove-feel.push-pull', label: 'Push-Pull', keywords: ['push-pull', 'tension', 'pushing'], paramContributions: { groove_feel: dw({ 'Push-Pull': 1.0 }) }, clusterMemberships: ['jazz-modal', 'prog-rock'] },
+        ],
+      },
+      {
+        id: 'rhythm.polyrhythm', label: 'Polyrhythm', keywords: ['polyrhythm', 'cross rhythm'],
+        children: [
+          { id: 'rhythm.polyrhythm.2-against-3', label: '2:3', keywords: ['two against three', '2:3', 'hemiola'], paramContributions: { groove_strength: rn(0.6, 0.9, 0.75) }, clusterMemberships: ['world-afrobeat', 'latin-salsa'] },
+          { id: 'rhythm.polyrhythm.3-against-4', label: '3:4', keywords: ['three against four', '3:4'], paramContributions: { groove_strength: rn(0.65, 0.9, 0.8) }, clusterMemberships: ['world-afrobeat', 'prog-rock'] },
+        ],
+      },
+    ],
+  },
+
+  // ═══ 4. DYNAMICS ═══
+  {
+    id: 'dynamics', label: 'Dynamics', keywords: ['dynamics', 'volume', 'loud', 'quiet'],
+    children: [
+      { id: 'dynamics.levels.pp', label: 'Pianissimo (pp)', keywords: ['pianissimo', 'very quiet', 'whisper', 'pp'], paramContributions: { dynamics: dw({ pp: 0.9, p: 0.1 }) }, clusterMemberships: ['ambient-pad', 'ambient-drone'] },
+      { id: 'dynamics.levels.p', label: 'Piano (p)', keywords: ['piano dynamics', 'quiet', 'soft', 'gentle', 'p'], paramContributions: { dynamics: dw({ p: 0.8, pp: 0.1, mp: 0.1 }) }, clusterMemberships: ['jazz-ballad', 'pop-ballad'] },
+      { id: 'dynamics.levels.mp', label: 'Mezzo Piano (mp)', keywords: ['mezzo piano', 'moderately quiet', 'mp'], paramContributions: { dynamics: dw({ mp: 0.8, p: 0.1, mf: 0.1 }) }, clusterMemberships: ['indie-folk', 'bossa-nova'] },
+      { id: 'dynamics.levels.mf', label: 'Mezzo Forte (mf)', keywords: ['mezzo forte', 'moderate', 'medium volume', 'mf'], paramContributions: { dynamics: dw({ mf: 0.8, mp: 0.1, f: 0.1 }) }, clusterMemberships: ['pop-upbeat', 'country-traditional'] },
+      { id: 'dynamics.levels.f', label: 'Forte (f)', keywords: ['forte', 'loud', 'strong', 'f'], paramContributions: { dynamics: dw({ f: 0.8, mf: 0.1, ff: 0.1 }) }, clusterMemberships: ['metal-shred', 'punk-rock'] },
+      { id: 'dynamics.levels.ff', label: 'Fortissimo (ff)', keywords: ['fortissimo', 'very loud', 'powerful', 'ff', 'aggressive'], paramContributions: { dynamics: dw({ ff: 0.9, f: 0.1 }) }, clusterMemberships: ['metal-shred', 'punk-rock', 'edm-drop'] },
+      {
+        id: 'dynamics.changes', label: 'Dynamic Changes', keywords: ['dynamic change'],
+        children: [
+          { id: 'dynamics.changes.crescendo', label: 'Crescendo', keywords: ['crescendo', 'building', 'getting louder'], paramContributions: { narrative_arc: dw({ 'Climb-to-Climax': 0.7, 'Rise and Fall': 0.3 }) }, clusterMemberships: ['cinematic-epic', 'post-rock'] },
+          { id: 'dynamics.changes.decrescendo', label: 'Decrescendo', keywords: ['decrescendo', 'diminuendo', 'fading', 'dying away'], paramContributions: { narrative_arc: dw({ Descent: 0.6, 'Slow Reveal': 0.4 }) }, clusterMemberships: ['ambient-pad'] },
+          { id: 'dynamics.changes.sforzando', label: 'Sforzando', keywords: ['sforzando', 'sudden accent', 'sfz'], paramContributions: {}, clusterMemberships: ['classical-romantic'] },
+        ],
+      },
+    ],
+  },
+
+  // ═══ 5. ARTICULATION ═══
+  {
+    id: 'articulation', label: 'Articulation', keywords: ['articulation', 'technique', 'playing style'],
+    children: [
+      { id: 'articulation.staccato', label: 'Staccato', keywords: ['staccato', 'short', 'detached', 'choppy'], paramContributions: {}, clusterMemberships: ['funk-groove', 'edm-house'] },
+      { id: 'articulation.legato', label: 'Legato', keywords: ['legato', 'smooth', 'connected', 'flowing'], paramContributions: {}, clusterMemberships: ['classical-romantic', 'metal-shred', 'ambient-pad'] },
+      { id: 'articulation.vibrato', label: 'Vibrato', keywords: ['vibrato', 'wobble', 'expression'], paramContributions: {}, clusterMemberships: ['blues-slow', 'classical-romantic'] },
+      { id: 'articulation.portamento', label: 'Portamento', keywords: ['portamento', 'slide', 'glide between notes'], paramContributions: {}, clusterMemberships: ['synthwave-retro', 'ambient-pad'] },
+      { id: 'articulation.tremolo', label: 'Tremolo', keywords: ['tremolo', 'rapid repeat', 'shake'], paramContributions: {}, clusterMemberships: ['classical-romantic'] },
+      { id: 'articulation.pizzicato', label: 'Pizzicato', keywords: ['pizzicato', 'plucked strings'], paramContributions: {}, clusterMemberships: ['classical-romantic'] },
+      { id: 'articulation.muted', label: 'Muted', keywords: ['muted', 'damped', 'ghost note'], paramContributions: {}, clusterMemberships: ['funk-groove', 'reggae'] },
+      { id: 'articulation.palm-mute', label: 'Palm Mute', keywords: ['palm mute', 'palm-muted', 'chug', 'chugging'], paramContributions: {}, clusterMemberships: ['metal-shred', 'punk-rock'] },
+      { id: 'articulation.fingerpicking', label: 'Fingerpicking', keywords: ['fingerpicking', 'fingerstyle', 'travis picking'], paramContributions: {}, clusterMemberships: ['indie-folk', 'country-traditional', 'bossa-nova'] },
+      { id: 'articulation.strumming', label: 'Strumming', keywords: ['strumming', 'strum', 'rhythm guitar'], paramContributions: {}, clusterMemberships: ['pop-upbeat', 'indie-folk', 'reggae'] },
+      { id: 'articulation.slap', label: 'Slap', keywords: ['slap', 'slap bass', 'pop and slap'], paramContributions: {}, clusterMemberships: ['funk-groove'] },
+      { id: 'articulation.tapping', label: 'Tapping', keywords: ['tapping', 'two-hand tapping'], paramContributions: {}, clusterMemberships: ['metal-shred', 'prog-rock'] },
+      { id: 'articulation.harmonics', label: 'Harmonics', keywords: ['harmonics', 'natural harmonics', 'artificial harmonics'], paramContributions: {}, clusterMemberships: ['post-rock', 'metal-shred'] },
+    ],
+  },
+
+  // ═══ 6. TEXTURE ═══
+  {
+    id: 'texture', label: 'Texture', keywords: ['texture', 'layering', 'thickness'],
+    children: [
+      { id: 'texture.density.monophonic', label: 'Monophonic', keywords: ['monophonic', 'single voice', 'unison'], paramContributions: { texture_density: rn(0, 0.15, 0.05) }, clusterMemberships: ['ambient-drone'] },
+      { id: 'texture.density.thin', label: 'Thin', keywords: ['thin', 'sparse texture', 'minimal'], paramContributions: { texture_density: rn(0.1, 0.3, 0.2) }, clusterMemberships: ['lo-fi-chill', 'indie-folk'] },
+      { id: 'texture.density.moderate', label: 'Moderate', keywords: ['moderate texture', 'balanced'], paramContributions: { texture_density: rn(0.3, 0.6, 0.45) }, clusterMemberships: ['pop-upbeat', 'neo-soul'] },
+      { id: 'texture.density.thick', label: 'Thick', keywords: ['thick', 'lush', 'full', 'rich', 'layered'], paramContributions: { texture_density: rn(0.6, 0.85, 0.7) }, clusterMemberships: ['cinematic-epic', 'synthwave-retro', 'gospel'] },
+      { id: 'texture.density.massive', label: 'Massive', keywords: ['massive', 'wall of sound', 'huge', 'epic'], paramContributions: { texture_density: rn(0.8, 1.0, 0.9) }, clusterMemberships: ['cinematic-epic', 'post-rock', 'edm-drop'] },
+      {
+        id: 'texture.space', label: 'Space', keywords: ['space', 'room', 'environment'],
+        children: [
+          { id: 'texture.space.intimate', label: 'Intimate', keywords: ['intimate', 'close', 'dry'], paramContributions: { space_probability: rn(0, 0.1, 0.05) }, clusterMemberships: ['lo-fi-chill', 'hip-hop-boom-bap'] },
+          { id: 'texture.space.room', label: 'Room', keywords: ['room', 'natural', 'studio'], paramContributions: { space_probability: rn(0.1, 0.25, 0.15) }, clusterMemberships: ['indie-folk', 'blues-slow'] },
+          { id: 'texture.space.hall', label: 'Hall', keywords: ['hall', 'spacious', 'concert hall'], paramContributions: { space_probability: rn(0.2, 0.4, 0.3) }, clusterMemberships: ['classical-romantic', 'gospel'] },
+          { id: 'texture.space.cathedral', label: 'Cathedral', keywords: ['cathedral', 'vast', 'reverberant'], paramContributions: { space_probability: rn(0.35, 0.55, 0.45) }, clusterMemberships: ['ambient-pad', 'post-rock'] },
+          { id: 'texture.space.infinite', label: 'Infinite', keywords: ['infinite', 'endless', 'void'], paramContributions: { space_probability: rn(0.5, 0.8, 0.65) }, clusterMemberships: ['ambient-drone'] },
+        ],
+      },
+    ],
+  },
+
+  // ═══ 7. STRUCTURE ═══
+  {
+    id: 'structure', label: 'Structure', keywords: ['structure', 'form', 'arrangement', 'song form'],
+    children: [
+      {
+        id: 'structure.sections', label: 'Sections', keywords: ['section', 'part'],
+        children: [
+          { id: 'structure.sections.intro', label: 'Intro', keywords: ['intro', 'introduction', 'opening'], paramContributions: {}, clusterMemberships: [] },
+          { id: 'structure.sections.verse', label: 'Verse', keywords: ['verse', 'stanza'], paramContributions: {}, clusterMemberships: [] },
+          { id: 'structure.sections.pre-chorus', label: 'Pre-Chorus', keywords: ['pre-chorus', 'build', 'lift'], paramContributions: {}, clusterMemberships: [] },
+          { id: 'structure.sections.chorus', label: 'Chorus', keywords: ['chorus', 'hook', 'refrain'], paramContributions: {}, clusterMemberships: [] },
+          { id: 'structure.sections.bridge', label: 'Bridge', keywords: ['bridge', 'middle eight', 'contrast'], paramContributions: {}, clusterMemberships: [] },
+          { id: 'structure.sections.outro', label: 'Outro', keywords: ['outro', 'ending', 'coda'], paramContributions: {}, clusterMemberships: [] },
+          { id: 'structure.sections.build', label: 'Build', keywords: ['build', 'buildup', 'riser'], paramContributions: {}, clusterMemberships: ['edm-drop'] },
+          { id: 'structure.sections.drop', label: 'Drop', keywords: ['drop', 'bass drop'], paramContributions: {}, clusterMemberships: ['edm-drop', 'edm-dnb'] },
+          { id: 'structure.sections.breakdown', label: 'Breakdown', keywords: ['breakdown', 'strip back'], paramContributions: {}, clusterMemberships: ['metal-shred', 'edm-drop'] },
+          { id: 'structure.sections.solo', label: 'Solo', keywords: ['solo', 'improvisation'], paramContributions: {}, clusterMemberships: ['metal-shred', 'blues-chicago', 'jazz-bebop'] },
+        ],
+      },
+      {
+        id: 'structure.narrative-arc', label: 'Narrative Arc', keywords: ['arc', 'trajectory', 'energy'],
+        children: [
+          { id: 'structure.narrative-arc.climb-to-climax', label: 'Climb to Climax', keywords: ['build', 'climax', 'crescendo', 'peak'], paramContributions: { narrative_arc: dw({ 'Climb-to-Climax': 1.0 }) }, clusterMemberships: ['cinematic-epic', 'post-rock', 'edm-drop'] },
+          { id: 'structure.narrative-arc.slow-reveal', label: 'Slow Reveal', keywords: ['reveal', 'gradual', 'unfolding'], paramContributions: { narrative_arc: dw({ 'Slow Reveal': 1.0 }) }, clusterMemberships: ['ambient-pad', 'post-rock'] },
+          { id: 'structure.narrative-arc.rise-and-fall', label: 'Rise and Fall', keywords: ['rise', 'fall', 'wave', 'arc'], paramContributions: { narrative_arc: dw({ 'Rise and Fall': 1.0 }) }, clusterMemberships: ['classical-romantic', 'pop-ballad'] },
+          { id: 'structure.narrative-arc.sudden-shift', label: 'Sudden Shift', keywords: ['sudden', 'shift', 'surprise', 'contrast'], paramContributions: { narrative_arc: dw({ 'Sudden Shift': 1.0 }) }, clusterMemberships: ['grunge', 'prog-rock'] },
+          { id: 'structure.narrative-arc.descent', label: 'Descent', keywords: ['descent', 'decline', 'winding down'], paramContributions: { narrative_arc: dw({ Descent: 1.0 }) }, clusterMemberships: ['ambient-drone'] },
+          { id: 'structure.narrative-arc.spiral', label: 'Spiral', keywords: ['spiral', 'cyclical', 'repetitive'], paramContributions: { narrative_arc: dw({ Spiral: 1.0 }) }, clusterMemberships: ['edm-house', 'ambient-drone'] },
+        ],
+      },
+    ],
+  },
+
+  // ═══ 8. TIMBRE ═══
+  {
+    id: 'timbre', label: 'Timbre', keywords: ['timbre', 'instrument', 'sound', 'tone'],
+    children: [
+      {
+        id: 'timbre.instruments', label: 'Instruments', keywords: ['instruments'],
+        children: [
+          { id: 'timbre.instruments.piano', label: 'Piano', keywords: ['piano', 'keys', 'keyboard', 'grand piano'], paramContributions: {}, clusterMemberships: ['jazz-modal', 'jazz-ballad', 'pop-ballad', 'classical-romantic', 'neo-soul', 'lo-fi-chill'] },
+          { id: 'timbre.instruments.electric-piano', label: 'Electric Piano', keywords: ['electric piano', 'rhodes', 'wurlitzer', 'ep'], paramContributions: {}, clusterMemberships: ['neo-soul', 'lo-fi-chill', 'funk-groove'] },
+          { id: 'timbre.instruments.organ', label: 'Organ', keywords: ['organ', 'hammond', 'b3'], paramContributions: {}, clusterMemberships: ['gospel', 'blues-chicago', 'reggae'] },
+          { id: 'timbre.instruments.acoustic-guitar', label: 'Acoustic Guitar', keywords: ['acoustic guitar', 'acoustic', 'nylon'], paramContributions: {}, clusterMemberships: ['indie-folk', 'country-traditional', 'bossa-nova', 'pop-ballad'] },
+          { id: 'timbre.instruments.electric-guitar', label: 'Electric Guitar', keywords: ['electric guitar', 'guitar', 'six string'], paramContributions: {}, clusterMemberships: ['metal-shred', 'punk-rock', 'grunge', 'blues-chicago', 'post-rock', 'indie-folk'] },
+          { id: 'timbre.instruments.bass-guitar', label: 'Bass Guitar', keywords: ['bass', 'bass guitar', 'electric bass'], paramContributions: {}, clusterMemberships: ['funk-groove', 'blues-slow', 'reggae', 'neo-soul', 'punk-rock'] },
+          { id: 'timbre.instruments.upright-bass', label: 'Upright Bass', keywords: ['upright bass', 'double bass', 'acoustic bass', 'walking bass'], paramContributions: {}, clusterMemberships: ['jazz-modal', 'jazz-bebop', 'jazz-ballad'] },
+          { id: 'timbre.instruments.synth-lead', label: 'Synth Lead', keywords: ['synth', 'synthesizer', 'lead synth'], paramContributions: {}, clusterMemberships: ['synthwave-retro', 'edm-drop', 'edm-house', 'pop-upbeat'] },
+          { id: 'timbre.instruments.synth-pad', label: 'Synth Pad', keywords: ['pad', 'synth pad', 'atmospheric'], paramContributions: {}, clusterMemberships: ['ambient-pad', 'ambient-drone', 'synthwave-retro', 'r-and-b-slow'] },
+          { id: 'timbre.instruments.synth-bass', label: 'Synth Bass', keywords: ['synth bass', 'sub bass', 'bass synth'], paramContributions: {}, clusterMemberships: ['edm-drop', 'edm-house', 'edm-dnb', 'hip-hop-trap'] },
+          { id: 'timbre.instruments.strings', label: 'Strings', keywords: ['strings', 'orchestral strings', 'string section'], paramContributions: {}, clusterMemberships: ['classical-romantic', 'cinematic-epic', 'pop-ballad'] },
+          { id: 'timbre.instruments.brass', label: 'Brass', keywords: ['brass', 'horns', 'brass section'], paramContributions: {}, clusterMemberships: ['latin-salsa', 'gospel', 'cinematic-epic', 'world-afrobeat'] },
+          { id: 'timbre.instruments.sax', label: 'Saxophone', keywords: ['sax', 'saxophone', 'alto sax', 'tenor sax'], paramContributions: {}, clusterMemberships: ['jazz-modal', 'jazz-bebop', 'neo-soul'] },
+          { id: 'timbre.instruments.drums', label: 'Drums', keywords: ['drums', 'drum kit', 'percussion'], paramContributions: {}, clusterMemberships: [] },
+          { id: 'timbre.instruments.choir', label: 'Choir', keywords: ['choir', 'vocals', 'voice', 'singing'], paramContributions: {}, clusterMemberships: ['gospel', 'cinematic-epic'] },
+          { id: 'timbre.instruments.808', label: '808', keywords: ['808', 'tr-808', 'trap bass', 'sub'], paramContributions: {}, clusterMemberships: ['hip-hop-trap', 'hip-hop-boom-bap'] },
+          { id: 'timbre.instruments.violin', label: 'Violin', keywords: ['violin', 'fiddle'], paramContributions: {}, clusterMemberships: ['classical-romantic', 'country-traditional'] },
+          { id: 'timbre.instruments.cello', label: 'Cello', keywords: ['cello'], paramContributions: {}, clusterMemberships: ['classical-romantic', 'cinematic-epic'] },
+          { id: 'timbre.instruments.flute', label: 'Flute', keywords: ['flute'], paramContributions: {}, clusterMemberships: ['classical-romantic', 'bossa-nova'] },
+          { id: 'timbre.instruments.harp', label: 'Harp', keywords: ['harp', 'arpeggiated'], paramContributions: {}, clusterMemberships: ['classical-romantic', 'ambient-pad'] },
+        ],
+      },
+      {
+        id: 'timbre.color', label: 'Tonal Color', keywords: ['tone', 'color', 'brightness'],
+        children: [
+          { id: 'timbre.color.bright', label: 'Bright', keywords: ['bright', 'shimmering', 'sparkling'], paramContributions: {}, clusterMemberships: ['pop-upbeat', 'video-game-chiptune'] },
+          { id: 'timbre.color.warm', label: 'Warm', keywords: ['warm', 'round', 'full'], paramContributions: {}, clusterMemberships: ['neo-soul', 'lo-fi-chill', 'jazz-ballad'] },
+          { id: 'timbre.color.dark', label: 'Dark', keywords: ['dark', 'murky', 'deep'], paramContributions: {}, clusterMemberships: ['metal-shred', 'ambient-drone', 'hip-hop-trap'] },
+          { id: 'timbre.color.gritty', label: 'Gritty', keywords: ['gritty', 'rough', 'raw', 'dirty'], paramContributions: {}, clusterMemberships: ['grunge', 'punk-rock', 'blues-chicago'] },
+        ],
+      },
+      {
+        id: 'timbre.effects', label: 'Effects', keywords: ['effects', 'fx', 'processing'],
+        children: [
+          { id: 'timbre.effects.distortion', label: 'Distortion', keywords: ['distortion', 'distorted', 'heavy', 'gain'], paramContributions: {}, clusterMemberships: ['metal-shred', 'punk-rock', 'grunge'] },
+          { id: 'timbre.effects.overdrive', label: 'Overdrive', keywords: ['overdrive', 'drive', 'crunch', 'tube'], paramContributions: {}, clusterMemberships: ['metal-shred', 'blues-chicago'] },
+          { id: 'timbre.effects.clean', label: 'Clean', keywords: ['clean', 'pristine', 'pure', 'unprocessed'], paramContributions: {}, clusterMemberships: ['blues-slow', 'jazz-modal', 'bossa-nova', 'indie-folk'] },
+          { id: 'timbre.effects.reverb', label: 'Reverb', keywords: ['reverb', 'spacious', 'reverberant'], paramContributions: { space_probability: rn(0.15, 0.45, 0.3) }, clusterMemberships: ['ambient-pad', 'post-rock', 'ambient-drone'] },
+          { id: 'timbre.effects.delay', label: 'Delay', keywords: ['delay', 'echo', 'repeat'], paramContributions: {}, clusterMemberships: ['post-rock', 'ambient-pad', 'reggae'] },
+          { id: 'timbre.effects.chorus-effect', label: 'Chorus', keywords: ['chorus effect', 'thicken', 'shimmer'], paramContributions: {}, clusterMemberships: ['synthwave-retro', 'indie-folk'] },
+          { id: 'timbre.effects.wah', label: 'Wah', keywords: ['wah', 'wah-wah', 'funk wah'], paramContributions: {}, clusterMemberships: ['funk-groove'] },
+          { id: 'timbre.effects.compression', label: 'Compression', keywords: ['compression', 'compressed', 'squash'], paramContributions: {}, clusterMemberships: [] },
+          { id: 'timbre.effects.bitcrusher', label: 'Bitcrusher', keywords: ['bitcrusher', 'bitcrushed', '8-bit', 'lo-res'], paramContributions: {}, clusterMemberships: ['video-game-chiptune'] },
+          { id: 'timbre.effects.lo-fi', label: 'Lo-Fi', keywords: ['lo-fi', 'lofi', 'tape', 'vinyl', 'vintage'], paramContributions: {}, clusterMemberships: ['lo-fi-chill'] },
+        ],
+      },
+    ],
+  },
+
+  // ═══ 9. EXPRESSION ═══
+  {
+    id: 'expression', label: 'Expression', keywords: ['expression', 'mood', 'emotion', 'feeling'],
+    children: [
+      { id: 'expression.mood.nostalgic', label: 'Nostalgic', keywords: ['nostalgic', 'nostalgia', 'memories', 'wistful'], paramContributions: { mode_weights: dw({ mixolydian: 0.4, major: 0.3, dorian: 0.3 }) }, clusterMemberships: ['lo-fi-chill', 'synthwave-retro'] },
+      { id: 'expression.mood.melancholic', label: 'Melancholic', keywords: ['melancholic', 'melancholy', 'somber', 'blue'], paramContributions: { mode_weights: dw({ minor: 0.5, dorian: 0.3, phrygian: 0.2 }) }, clusterMemberships: ['post-rock', 'pop-ballad'] },
+      { id: 'expression.mood.grief', label: 'Grief', keywords: ['grief', 'loss', 'mourning', 'devastation'], paramContributions: { mode_weights: dw({ minor: 0.6, phrygian: 0.2, dorian: 0.2 }) }, clusterMemberships: ['ambient-pad', 'classical-romantic'] },
+      { id: 'expression.mood.tender', label: 'Tender', keywords: ['tender', 'gentle', 'delicate', 'fragile'], paramContributions: { dynamics: dw({ p: 0.4, mp: 0.4, pp: 0.2 }) }, clusterMemberships: ['jazz-ballad', 'pop-ballad'] },
+      { id: 'expression.mood.romantic', label: 'Romantic', keywords: ['romantic', 'love', 'passionate'], paramContributions: { mode_weights: dw({ major: 0.4, lydian: 0.3, dorian: 0.3 }) }, clusterMemberships: ['classical-romantic', 'r-and-b-slow'] },
+      { id: 'expression.mood.hopeful', label: 'Hopeful', keywords: ['hopeful', 'hope', 'uplifting', 'optimistic'], paramContributions: { mode_weights: dw({ major: 0.5, lydian: 0.3, mixolydian: 0.2 }) }, clusterMemberships: ['pop-upbeat', 'gospel'] },
+      { id: 'expression.mood.joyful', label: 'Joyful', keywords: ['joyful', 'happy', 'cheerful', 'bright', 'celebration'], paramContributions: { mode_weights: dw({ major: 0.5, lydian: 0.3, mixolydian: 0.2 }) }, clusterMemberships: ['pop-upbeat', 'gospel', 'latin-salsa'] },
+      { id: 'expression.mood.energetic', label: 'Energetic', keywords: ['energetic', 'high energy', 'pumping', 'adrenaline'], paramContributions: { density: dw({ dense: 0.6, medium: 0.4 }), dynamics: dw({ f: 0.5, ff: 0.3, mf: 0.2 }) }, clusterMemberships: ['edm-drop', 'punk-rock', 'metal-shred'] },
+      { id: 'expression.mood.fierce', label: 'Fierce', keywords: ['fierce', 'intense', 'aggressive', 'brutal'], paramContributions: { density: dw({ dense: 0.7, medium: 0.3 }), dynamics: dw({ ff: 0.6, f: 0.4 }) }, clusterMemberships: ['metal-shred', 'punk-rock', 'edm-dnb'] },
+      { id: 'expression.mood.mysterious', label: 'Mysterious', keywords: ['mysterious', 'enigmatic', 'dark', 'haunting'], paramContributions: { mode_weights: dw({ phrygian: 0.3, minor: 0.3, dorian: 0.2, locrian: 0.2 }) }, clusterMemberships: ['ambient-pad', 'cinematic-epic'] },
+      { id: 'expression.mood.ethereal', label: 'Ethereal', keywords: ['ethereal', 'otherworldly', 'heavenly', 'floating'], paramContributions: { mode_weights: dw({ lydian: 0.4, major: 0.3, whole_tone: 0.3 }), space_probability: rn(0.2, 0.5, 0.35) }, clusterMemberships: ['ambient-pad', 'post-rock'] },
+      { id: 'expression.mood.calm', label: 'Calm', keywords: ['calm', 'peaceful', 'serene', 'tranquil', 'zen'], paramContributions: { mode_weights: dw({ major: 0.4, lydian: 0.3, mixolydian: 0.3 }), density: dw({ sparse: 0.6, medium: 0.4 }) }, clusterMemberships: ['ambient-pad', 'jazz-ballad', 'bossa-nova'] },
+    ],
+  },
+
+  // ═══ 10. PRODUCTION ═══
+  {
+    id: 'production', label: 'Production', keywords: ['production', 'mix', 'spatial', 'engineering'],
+    children: [
+      {
+        id: 'production.register', label: 'Register', keywords: ['register', 'frequency range'],
+        children: [
+          { id: 'production.register.sub-bass', label: 'Sub Bass', keywords: ['sub bass', 'sub', 'rumble', 'below 80hz'], paramContributions: {}, clusterMemberships: ['hip-hop-trap', 'edm-drop'] },
+          { id: 'production.register.bass', label: 'Bass', keywords: ['bass register', 'low', 'bottom'], paramContributions: {}, clusterMemberships: ['reggae', 'edm-dnb'] },
+          { id: 'production.register.mid', label: 'Mid', keywords: ['mid range', 'middle', 'presence'], paramContributions: {}, clusterMemberships: [] },
+          { id: 'production.register.high', label: 'High', keywords: ['high register', 'treble', 'bright', 'air'], paramContributions: {}, clusterMemberships: [] },
+        ],
+      },
+      {
+        id: 'production.spatial', label: 'Spatial', keywords: ['spatial', 'stereo', 'width'],
+        children: [
+          { id: 'production.spatial.mono', label: 'Mono', keywords: ['mono', 'center', 'focused'], paramContributions: {}, clusterMemberships: ['lo-fi-chill'] },
+          { id: 'production.spatial.narrow-stereo', label: 'Narrow Stereo', keywords: ['narrow', 'tight stereo'], paramContributions: {}, clusterMemberships: ['hip-hop-boom-bap'] },
+          { id: 'production.spatial.wide-stereo', label: 'Wide Stereo', keywords: ['wide', 'stereo', 'spacious', 'panoramic'], paramContributions: {}, clusterMemberships: ['post-rock', 'cinematic-epic', 'ambient-pad'] },
+        ],
+      },
+      {
+        id: 'production.mix-style', label: 'Mix Style', keywords: ['mix', 'style', 'aesthetic'],
+        children: [
+          { id: 'production.mix-style.raw', label: 'Raw', keywords: ['raw', 'unpolished', 'live feel'], paramContributions: {}, clusterMemberships: ['punk-rock', 'grunge'] },
+          { id: 'production.mix-style.polished', label: 'Polished', keywords: ['polished', 'clean', 'professional', 'hi-fi'], paramContributions: {}, clusterMemberships: ['pop-upbeat', 'edm-house'] },
+          { id: 'production.mix-style.lo-fi', label: 'Lo-Fi', keywords: ['lo-fi mix', 'lofi', 'tape saturation', 'vinyl crackle'], paramContributions: {}, clusterMemberships: ['lo-fi-chill'] },
+          { id: 'production.mix-style.saturated', label: 'Saturated', keywords: ['saturated', 'warm', 'analog', 'tape'], paramContributions: {}, clusterMemberships: ['neo-soul', 'synthwave-retro'] },
+        ],
+      },
+    ],
+  },
+];
+
+/** Flatten the taxonomy tree to a Map for O(1) lookup by ID */
+export function flattenTaxonomy(nodes: TaxonomyNode[]): Map<string, TaxonomyNode> {
+  const map = new Map<string, TaxonomyNode>();
+  function walk(nodeList: TaxonomyNode[]) {
+    for (const node of nodeList) {
+      map.set(node.id, node);
+      if (node.children) walk(node.children);
+    }
+  }
+  walk(nodes);
+  return map;
+}

--- a/src/hooks/useMusicBrain.ts
+++ b/src/hooks/useMusicBrain.ts
@@ -363,6 +363,26 @@ export const useMusicBrain = () => {
     return apiCall('/audio/models');
   };
 
+  const parseText = async (
+    text: string,
+    locale?: string,
+    userId?: string,
+    signal?: AbortSignal,
+  ): Promise<import('../types/Interpretation').ParseTextResponse> => {
+    // Bypass USE_EXTERNAL_API gate — parse-text is a local dev tool,
+    // not a cloud dependency. Always try the local API directly.
+    const resp = await fetch(`${API_BASE}/parse-text`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text, locale: locale ?? 'en', user_id: userId }),
+      signal,
+    });
+    if (!resp.ok) {
+      throw new Error(`parse-text failed (${resp.status})`);
+    }
+    return resp.json();
+  };
+
   const healthCheck = async (): Promise<{ status: string; version: string }> => {
     if (!USE_EXTERNAL_API) {
       return Promise.reject(new Error('API disabled (no cloud required)'));
@@ -385,6 +405,7 @@ export const useMusicBrain = () => {
     classifyAudio,
     getAudioValenceArousal,
     getAudioModels,
+    parseText,
     healthCheck,
   };
 };

--- a/src/hooks/useTextParse.ts
+++ b/src/hooks/useTextParse.ts
@@ -1,0 +1,159 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useMusicBrain } from './useMusicBrain';
+import type { ParseTextResponse } from '../types/Interpretation';
+
+interface UseTextParseOptions {
+  debounceMs?: number;
+  locale?: string;
+}
+
+interface UseTextParseResult {
+  /** Current parse result from the backend */
+  parseResult: ParseTextResponse | null;
+  /** Whether a parse request is in flight */
+  isParsing: boolean;
+  /** Parse text immediately (bypasses debounce) */
+  parseNow: (text: string) => void;
+  /** Parse text with debounce */
+  parseDebounced: (text: string) => void;
+  /** Force a reparse of the latest text */
+  forceReparse: () => void;
+  /** Last error, if any */
+  error: string | null;
+}
+
+/**
+ * Hook that debounces text input and sends it to POST /parse-text.
+ *
+ * Returns probabilistic distributions, activated context clusters,
+ * and taxonomy node IDs from the backend NLP service.
+ */
+export function useTextParse(options?: UseTextParseOptions): UseTextParseResult {
+  const { debounceMs = 300, locale = 'en' } = options ?? {};
+
+  const brain = useMusicBrain();
+  const [parseResult, setParseResult] = useState<ParseTextResponse | null>(null);
+  const [isParsing, setIsParsing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const abortRef = useRef<AbortController | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const latestTextRef = useRef('');
+
+  const doParseRequest = useCallback(async (text: string) => {
+    if (!text.trim()) {
+      setParseResult(null);
+      setIsParsing(false);
+      return;
+    }
+
+    // Cancel any in-flight request
+    abortRef.current?.abort();
+    abortRef.current = new AbortController();
+
+    setIsParsing(true);
+    setError(null);
+
+    try {
+      const result = await brain.parseText(text, locale, undefined, abortRef.current?.signal);
+      // Only update if this is still the latest request
+      if (text === latestTextRef.current) {
+        setParseResult(result);
+        setIsParsing(false);
+      }
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') return;
+      if (text === latestTextRef.current) {
+        // On API failure, try offline keyword matching
+        setParseResult(offlineFallback(text));
+        setError(err instanceof Error ? err.message : 'Parse failed');
+        setIsParsing(false);
+      }
+    }
+  }, [brain, locale]);
+
+  const parseDebounced = useCallback((text: string) => {
+    latestTextRef.current = text;
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => doParseRequest(text), debounceMs);
+  }, [doParseRequest, debounceMs]);
+
+  const parseNow = useCallback((text: string) => {
+    latestTextRef.current = text;
+    if (timerRef.current) clearTimeout(timerRef.current);
+    doParseRequest(text);
+  }, [doParseRequest]);
+
+  const forceReparse = useCallback(() => {
+    if (latestTextRef.current.trim()) {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      doParseRequest(latestTextRef.current);
+    }
+  }, [doParseRequest]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  return { parseResult, isParsing, parseNow, parseDebounced, forceReparse, error };
+}
+
+/**
+ * Client-side keyword matching fallback when the API is offline.
+ *
+ * Scans text for known musical terms and returns basic taxonomy hints.
+ * Much simpler than the backend NLP but provides usable feedback.
+ */
+function offlineFallback(text: string): ParseTextResponse {
+  const lower = text.toLowerCase();
+  const keywords: string[] = [];
+  const taxonomyIds: string[] = [];
+
+  const KEYWORD_TO_TAXONOMY: Record<string, string> = {
+    'dorian': 'harmony.scales.dorian',
+    'phrygian': 'harmony.scales.phrygian',
+    'lydian': 'harmony.scales.lydian',
+    'mixolydian': 'harmony.scales.mixolydian',
+    'minor': 'harmony.scales.minor',
+    'major': 'harmony.scales.major',
+    'pentatonic': 'harmony.scales.pentatonic-minor',
+    'blues': 'harmony.scales.blues',
+    'guitar': 'timbre.instruments.electric-guitar',
+    'bass': 'timbre.instruments.bass-guitar',
+    'piano': 'timbre.instruments.piano',
+    'synth': 'timbre.instruments.synth-lead',
+    'drums': 'timbre.instruments.drums',
+    'strings': 'timbre.instruments.strings',
+    'overdrive': 'timbre.effects.overdrive',
+    'distortion': 'timbre.effects.distortion',
+    'clean': 'timbre.effects.clean',
+    'reverb': 'timbre.effects.reverb',
+    'fast': 'rhythm.density.dense',
+    'slow': 'rhythm.density.sparse',
+    'staccato': 'articulation.staccato',
+    'legato': 'articulation.legato',
+    'loud': 'dynamics.levels.f',
+    'quiet': 'dynamics.levels.p',
+    'sparse': 'rhythm.density.sparse',
+    'dense': 'rhythm.density.dense',
+  };
+
+  for (const [word, taxId] of Object.entries(KEYWORD_TO_TAXONOMY)) {
+    if (lower.includes(word)) {
+      keywords.push(word);
+      taxonomyIds.push(taxId);
+    }
+  }
+
+  return {
+    param_distributions: {},
+    activated_clusters: [],
+    activated_taxonomy_ids: taxonomyIds,
+    detected_keywords: keywords,
+    confidence: Math.min(1, keywords.length / 5) * 0.5, // lower confidence for offline
+  };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1905,3 +1905,590 @@ button { cursor: pointer; }
     transition-duration: 0.01ms !important;
   }
 }
+
+
+/* ═══════════════════════════════════════════════════
+   Universal Music Input — Dual-pane layout
+   ═══════════════════════════════════════════════════ */
+
+.umi-container {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr auto;
+  gap: var(--space-3);
+  min-height: calc(100vh - 100px);
+}
+
+.umi-side-a,
+.umi-side-b {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.umi-side-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-2);
+}
+
+.umi-side-title {
+  font-family: var(--font-display);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin: 0;
+}
+
+/* --- Command Palette --- */
+.umi-command-palette {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+}
+
+.umi-search-box {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  background: var(--surface-inset);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0 var(--space-2);
+}
+
+.umi-search-box:focus-within {
+  border-color: var(--accent-muted);
+}
+
+.umi-search-icon {
+  color: var(--text-muted);
+  font-size: 14px;
+  margin-right: var(--space-1);
+}
+
+.umi-search-input {
+  flex: 1;
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  font-family: var(--font-ui);
+  font-size: 13px;
+  padding: 6px 0;
+  outline: none;
+}
+
+.umi-search-input::placeholder {
+  color: var(--text-muted);
+}
+
+.umi-search-clear {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 2px;
+}
+
+.umi-active-count {
+  font-size: 11px;
+  color: var(--accent);
+  white-space: nowrap;
+}
+
+/* --- Taxonomy Tree --- */
+.umi-tree-scroll {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding-right: var(--space-1);
+}
+
+.umi-taxonomy-tree {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.umi-tree-branch {
+  margin-left: calc(var(--space-2) * attr(data-depth integer, 0));
+}
+
+.umi-tree-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  width: 100%;
+  padding: 4px var(--space-2);
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  border-radius: var(--radius);
+}
+
+.umi-tree-header:hover {
+  background: var(--surface-raised);
+}
+
+.umi-tree-arrow {
+  font-size: 8px;
+  width: 12px;
+  text-align: center;
+  color: var(--text-muted);
+}
+
+.umi-tree-label { flex: 1; text-align: left; }
+
+.umi-tree-badge {
+  font-size: 10px;
+  background: var(--accent-muted);
+  color: var(--accent);
+  padding: 0 5px;
+  border-radius: 8px;
+  font-weight: 700;
+}
+
+.umi-tree-children {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding-left: var(--space-3);
+  margin-top: 2px;
+}
+
+/* --- Taxonomy Node Chip --- */
+.umi-node-chip {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 3px var(--space-2);
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-secondary);
+  font-family: var(--font-ui);
+  font-size: 12px;
+  cursor: pointer;
+  overflow: hidden;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.umi-node-chip:hover {
+  border-color: var(--border-hover);
+  background: var(--surface-overlay);
+}
+
+.umi-node-chip.active {
+  border-color: var(--accent-muted);
+  color: var(--text-primary);
+}
+
+.umi-node-chip.nlp-detected {
+  border-color: rgba(201, 162, 39, 0.12);
+  border-style: dashed;
+}
+
+.umi-node-chip-fill {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  background: var(--accent-muted);
+  transition: width 0.3s ease;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.umi-node-chip-label {
+  position: relative;
+  z-index: 1;
+  flex: 1;
+  text-align: left;
+}
+
+.umi-node-chip-weight {
+  position: relative;
+  z-index: 1;
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--accent);
+  font-family: var(--font-mono);
+}
+
+.umi-node-chip-pin {
+  position: relative;
+  z-index: 1;
+  font-size: 10px;
+  cursor: pointer;
+  opacity: 0.4;
+  transition: opacity 0.15s;
+}
+
+.umi-node-chip-pin:hover,
+.umi-node-chip-pin.pinned {
+  opacity: 1;
+}
+
+/* --- Interpretive Slider --- */
+.umi-interpretive-slider {
+  padding: var(--space-2) 0;
+  border-top: 1px solid var(--border);
+  margin-top: var(--space-2);
+}
+
+.umi-slider-label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.umi-slider-end {
+  font-size: 10px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  white-space: nowrap;
+}
+
+.umi-slider-input {
+  flex: 1;
+  -webkit-appearance: none;
+  appearance: none;
+  height: 4px;
+  background: linear-gradient(to right, var(--accent-muted), var(--accent));
+  border-radius: 2px;
+  outline: none;
+}
+
+.umi-slider-input::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--accent);
+  cursor: pointer;
+  border: 2px solid var(--surface);
+}
+
+/* --- Natural Language Input --- */
+.umi-nl-input-wrap {
+  position: relative;
+  margin-bottom: var(--space-2);
+}
+
+.umi-nl-textarea {
+  width: 100%;
+  min-height: 120px;
+  padding: var(--space-3);
+  background: var(--surface-inset);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-primary);
+  font-family: var(--font-ui);
+  font-size: 14px;
+  line-height: 1.5;
+  resize: vertical;
+  outline: none;
+}
+
+.umi-nl-textarea:focus {
+  border-color: var(--accent-muted);
+}
+
+.umi-nl-textarea::placeholder {
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.umi-parsing-indicator {
+  position: absolute;
+  bottom: var(--space-2);
+  right: var(--space-2);
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-size: 11px;
+  color: var(--accent);
+}
+
+.umi-parsing-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: umi-pulse 1s ease-in-out infinite;
+}
+
+@keyframes umi-pulse {
+  0%, 100% { opacity: 0.3; }
+  50% { opacity: 1; }
+}
+
+/* --- Context Feedback --- */
+.umi-context-feedback {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  flex: 1;
+  overflow-y: auto;
+}
+
+.umi-cluster-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-3);
+  background: var(--accent-muted);
+  border-radius: var(--radius);
+  align-self: flex-start;
+}
+
+.umi-cluster-label {
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--accent);
+}
+
+.umi-cluster-confidence {
+  font-size: 11px;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+}
+
+.umi-detected-keywords {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+}
+
+.umi-keyword-tag {
+  font-size: 11px;
+  padding: 1px 6px;
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+}
+
+/* --- Distribution Bar --- */
+.umi-distribution-bar,
+.umi-tempo-range {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.umi-dist-label {
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  min-width: 40px;
+}
+
+.umi-dist-segments {
+  flex: 1;
+  display: flex;
+  height: 18px;
+  border-radius: 3px;
+  overflow: hidden;
+  gap: 1px;
+}
+
+.umi-dist-segment {
+  background: var(--accent-muted);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  transition: flex 0.3s ease;
+}
+
+.umi-dist-segment:first-child { border-radius: 3px 0 0 3px; }
+.umi-dist-segment:last-child { border-radius: 0 3px 3px 0; }
+
+.umi-dist-segment-label {
+  font-size: 9px;
+  font-family: var(--font-mono);
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding: 0 3px;
+}
+
+.umi-tempo-value {
+  font-size: 12px;
+  font-family: var(--font-mono);
+  color: var(--text-primary);
+}
+
+.umi-confidence-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: var(--space-1);
+  border-top: 1px solid var(--border);
+}
+
+.umi-confidence-label {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.umi-reinterpret-btn {
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-secondary);
+  font-size: 12px;
+  padding: 3px 8px;
+  cursor: pointer;
+}
+
+.umi-reinterpret-btn:hover {
+  border-color: var(--accent-muted);
+  color: var(--text-primary);
+}
+
+/* --- Summary Bar --- */
+.umi-summary-bar {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+}
+
+.umi-summary-text {
+  flex: 1;
+  font-size: 13px;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.umi-summary-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.umi-reinterpret-btn-sm {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 4px 6px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.umi-reinterpret-btn-sm:hover {
+  border-color: var(--accent-muted);
+}
+
+.umi-generate-btn {
+  background: var(--accent);
+  color: #050506;
+  border: none;
+  border-radius: var(--radius);
+  padding: 6px 16px;
+  font-weight: 600;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.umi-generate-btn:hover:not(:disabled) {
+  background: var(--accent-hover);
+}
+
+.umi-generate-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.umi-api-status {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.umi-status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+}
+
+.umi-api-status.online .umi-status-dot { background: var(--success); }
+.umi-api-status.offline .umi-status-dot { background: var(--danger); }
+.umi-api-status.checking .umi-status-dot { background: var(--text-muted); }
+
+/* --- Tool Drawer --- */
+.umi-drawer-toggle {
+  grid-column: 1 / -1;
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-muted);
+  font-size: 12px;
+  padding: 4px var(--space-3);
+  cursor: pointer;
+  text-align: center;
+}
+
+.umi-drawer-toggle:hover {
+  border-color: var(--border-hover);
+  color: var(--text-secondary);
+}
+
+.umi-drawer {
+  grid-column: 1 / -1;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-3);
+}
+
+.umi-drawer-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--space-3);
+}
+
+/* --- Responsive --- */
+@media (max-width: 768px) {
+  .umi-container {
+    grid-template-columns: 1fr;
+  }
+  .umi-summary-bar {
+    grid-column: 1;
+  }
+  .umi-drawer-toggle,
+  .umi-drawer {
+    grid-column: 1;
+  }
+}

--- a/src/types/Interpretation.ts
+++ b/src/types/Interpretation.ts
@@ -1,0 +1,27 @@
+/**
+ * Types for the Universal Music Input probabilistic interpretation system.
+ */
+
+/** A probability distribution over possible values */
+export interface ParamDistribution {
+  type: 'gaussian' | 'discrete' | 'range';
+  center?: number;
+  spread?: number;
+  weights?: Record<string, number>;
+  min?: number;
+  max?: number;
+  bias?: number;
+}
+
+/** Response from POST /parse-text backend endpoint */
+export interface ParseTextResponse {
+  param_distributions: Record<string, ParamDistribution>;
+  activated_clusters: Array<{
+    id: string;
+    confidence: number;
+    label: string;
+  }>;
+  activated_taxonomy_ids: string[];
+  detected_keywords: string[];
+  confidence: number;
+}

--- a/tests/unit/test_api_parse_text.py
+++ b/tests/unit/test_api_parse_text.py
@@ -25,9 +25,7 @@ RESPONSE_KEYS = {
 
 def test_parse_text_returns_interpretation(client):
     """A musical description yields distributions, clusters, and taxonomy ids."""
-    r = client.post(
-        "/parse-text", json={"text": "slow bluesy dorian, clean tone, laid back"}
-    )
+    r = client.post("/parse-text", json={"text": "slow bluesy dorian, clean tone, laid back"})
     assert r.status_code == 200
     body = r.json()
     assert RESPONSE_KEYS <= set(body.keys())
@@ -59,9 +57,7 @@ def test_parse_text_empty_text_returns_defaults(client):
 
 def test_parse_text_non_musical_text_low_confidence(client):
     """Prose without musical terms yields low confidence but a usable payload."""
-    r = client.post(
-        "/parse-text", json={"text": "please file the expense report by friday"}
-    )
+    r = client.post("/parse-text", json={"text": "please file the expense report by friday"})
     assert r.status_code == 200
     body = r.json()
     assert body["confidence"] < 0.5

--- a/tests/unit/test_api_parse_text.py
+++ b/tests/unit/test_api_parse_text.py
@@ -1,0 +1,68 @@
+"""Tests for POST /parse-text: natural language -> probabilistic music parameters."""
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(scope="module")
+def client():
+    from fastapi.testclient import TestClient
+
+    from music_brain.api import app
+
+    return TestClient(app)
+
+
+RESPONSE_KEYS = {
+    "param_distributions",
+    "activated_clusters",
+    "activated_taxonomy_ids",
+    "detected_keywords",
+    "confidence",
+}
+
+
+def test_parse_text_returns_interpretation(client):
+    """A musical description yields distributions, clusters, and taxonomy ids."""
+    r = client.post(
+        "/parse-text", json={"text": "slow bluesy dorian, clean tone, laid back"}
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert RESPONSE_KEYS <= set(body.keys())
+    assert "blues-slow" in [c["id"] for c in body["activated_clusters"]]
+    assert body["param_distributions"]["tempo"]["center"] <= 100
+    assert "harmony.scales.dorian" in body["activated_taxonomy_ids"]
+
+
+def test_parse_text_missing_text_field(client):
+    """Requests without the required text field are rejected."""
+    r = client.post("/parse-text", json={"locale": "en"})
+    assert r.status_code == 422
+
+
+def test_parse_text_rejects_overlong_text(client):
+    """Text beyond the 4096-char cap is rejected by validation."""
+    r = client.post("/parse-text", json={"text": "x" * 4097})
+    assert r.status_code == 422
+
+
+def test_parse_text_empty_text_returns_defaults(client):
+    """Empty text is not an error: defaults come back with no detections."""
+    r = client.post("/parse-text", json={"text": ""})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["detected_keywords"] == []
+    assert "tempo" in body["param_distributions"]
+
+
+def test_parse_text_non_musical_text_low_confidence(client):
+    """Prose without musical terms yields low confidence but a usable payload."""
+    r = client.post(
+        "/parse-text", json={"text": "please file the expense report by friday"}
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["confidence"] < 0.5
+    assert body["detected_keywords"] == []

--- a/tests/unit/test_nlp_text_to_intent.py
+++ b/tests/unit/test_nlp_text_to_intent.py
@@ -1,0 +1,199 @@
+"""Tests for music_brain.nlp: KeywordExtractor and TextToIntentService.
+
+The NLP layer converts free-text music descriptions into probabilistic
+parameter distributions. Core behavior under test: the same keyword
+("dorian") yields different interpretations in different contexts
+(metal shred vs slow blues), and the service degrades gracefully when
+the optional emotion parser is unavailable.
+"""
+
+import json
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# KeywordExtractor
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def extractor():
+    from music_brain.nlp.keyword_extractor import KeywordExtractor
+
+    return KeywordExtractor()
+
+
+def test_extracts_instruments(extractor):
+    """Concrete instrument words are extracted with taxonomy hints."""
+    result = extractor.extract("guitar and piano over drums")
+    assert "guitar" in result.instruments
+    assert "piano" in result.instruments
+    assert "drums" in result.instruments
+    assert "timbre.instruments.piano" in result.taxonomy_hints
+
+
+def test_multi_word_keywords_take_priority(extractor):
+    """ "electric guitar" matches as one keyword, not as bare "guitar"."""
+    result = extractor.extract("electric guitar riff")
+    assert "electric guitar" in result.all_matched
+    assert "guitar" not in result.all_matched
+
+
+def test_word_boundaries_respected(extractor):
+    """Substrings inside larger words do not match (bassoon != bass)."""
+    result = extractor.extract("the bassoon player")
+    assert result.instruments == []
+    assert result.all_matched == []
+
+
+def test_categorizes_keywords(extractor):
+    """Keywords land in their semantic category buckets."""
+    result = extractor.extract("slow dorian blues")
+    assert "slow" in result.tempo_words
+    assert "dorian" in result.mode_words
+    assert "blues" in result.genre_markers
+
+
+def test_case_insensitive(extractor):
+    """Extraction is case-insensitive."""
+    result = extractor.extract("GUITAR with Overdrive")
+    assert "guitar" in result.instruments
+    assert "overdrive" in result.techniques
+
+
+def test_empty_text(extractor):
+    """Empty input produces empty results."""
+    result = extractor.extract("")
+    assert result.all_matched == []
+    assert result.taxonomy_hints == []
+
+
+# ---------------------------------------------------------------------------
+# TextToIntentService
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def service():
+    from music_brain.nlp.text_to_intent_service import TextToIntentService
+
+    return TextToIntentService()
+
+
+RESPONSE_KEYS = {
+    "param_distributions",
+    "activated_clusters",
+    "activated_taxonomy_ids",
+    "detected_keywords",
+    "confidence",
+}
+
+
+def test_parse_returns_response_schema(service):
+    """parse() returns the ParseTextResponse contract used by the frontend."""
+    result = service.parse("slow bluesy dorian with clean bass")
+    assert RESPONSE_KEYS <= set(result.keys())
+    assert isinstance(result["param_distributions"], dict)
+    assert isinstance(result["activated_clusters"], list)
+    assert isinstance(result["activated_taxonomy_ids"], list)
+    assert isinstance(result["detected_keywords"], list)
+    assert 0.0 <= result["confidence"] <= 1.0
+
+
+def test_parse_result_is_json_serializable(service):
+    """The endpoint returns the parse dict verbatim, so it must serialize."""
+    result = service.parse("fast metal guitar with distortion")
+    json.dumps(result)
+
+
+def test_metal_context_activates_shred_cluster(service):
+    """Metal context: high-tempo cluster activates."""
+    result = service.parse("fast metal shred on dorian with distorted guitar")
+    cluster_ids = [c["id"] for c in result["activated_clusters"]]
+    assert "metal-shred" in cluster_ids
+    tempo = result["param_distributions"]["tempo"]
+    assert tempo["type"] == "gaussian"
+    assert tempo["center"] >= 140
+
+
+def test_blues_context_activates_slow_cluster(service):
+    """Blues context: laid-back low-tempo cluster activates."""
+    result = service.parse("slow bluesy dorian, clean tone, laid back")
+    cluster_ids = [c["id"] for c in result["activated_clusters"]]
+    assert "blues-slow" in cluster_ids
+    tempo = result["param_distributions"]["tempo"]
+    assert tempo["center"] <= 100
+
+
+def test_same_mode_word_interpreted_by_context(service):
+    """Flagship behavior: "dorian" means shred or blues depending on context."""
+    metal = service.parse("fast metal shred on dorian with distorted guitar")
+    blues = service.parse("slow bluesy dorian, clean tone, laid back")
+    metal_tempo = metal["param_distributions"]["tempo"]["center"]
+    blues_tempo = blues["param_distributions"]["tempo"]["center"]
+    assert metal_tempo > blues_tempo + 30
+
+
+def test_mode_keywords_boost_mode_weights(service):
+    """Explicitly named modes get boosted in mode_weights."""
+    result = service.parse("a dorian groove")
+    weights = result["param_distributions"]["mode_weights"]["weights"]
+    assert weights.get("dorian", 0) > 0
+
+
+def test_cluster_activation_entries_are_well_formed(service):
+    """Each activated cluster carries id, label, and bounded confidence."""
+    result = service.parse("slow bluesy dorian, clean tone, laid back")
+    assert result["activated_clusters"], "expected at least one activated cluster"
+    for cluster in result["activated_clusters"]:
+        assert cluster["id"]
+        assert cluster["label"]
+        assert 0.0 <= cluster["confidence"] <= 1.0
+    labels = [c["label"] for c in result["activated_clusters"]]
+    assert "Slow Blues" in labels
+
+
+def test_at_most_five_clusters(service):
+    """Cluster activations are capped at the top 5."""
+    text = (
+        "fast slow metal blues jazz funk ambient pop punk reggae "
+        "guitar bass piano synth drums distortion clean reverb "
+        "dorian minor major pentatonic"
+    )
+    result = service.parse(text)
+    assert len(result["activated_clusters"]) <= 5
+
+
+def test_non_musical_text_yields_defaults(service):
+    """Text with no musical keywords still returns usable default distributions."""
+    result = service.parse("the quarterly report is due on thursday")
+    assert result["detected_keywords"] == []
+    assert result["confidence"] < 0.5
+    dists = result["param_distributions"]
+    for required in ("tempo", "mode_weights", "density"):
+        assert required in dists
+
+
+def test_degrades_without_emotion_parser(service, monkeypatch):
+    """Service still fulfills the contract when optional emotion deps are absent."""
+    from music_brain.nlp import text_to_intent_service as mod
+
+    monkeypatch.setattr(mod, "_get_emotion_parser", lambda: None)
+    monkeypatch.setattr(mod, "_get_emotional_mapping", lambda: None)
+    result = service.parse("slow bluesy dorian, clean tone, laid back")
+    assert RESPONSE_KEYS <= set(result.keys())
+    assert "tempo" in result["param_distributions"]
+    cluster_ids = [c["id"] for c in result["activated_clusters"]]
+    assert "blues-slow" in cluster_ids
+
+
+def test_param_distribution_to_dict_omits_unset_fields():
+    """ParamDistribution.to_dict() emits only the fields relevant to its type."""
+    from music_brain.nlp.text_to_intent_service import ParamDistribution
+
+    gaussian = ParamDistribution("gaussian", center=120.0, spread=10.0)
+    as_dict = gaussian.to_dict()
+    assert as_dict == {"type": "gaussian", "center": 120.0, "spread": 10.0}


### PR DESCRIPTION
## Summary

Ports the Universal Music Input feature from tag `archive/feature/integration-finalize` (originally commit `0ca143b4`, March 2026) into current main, per the June 2026 salvage analysis (rated MEDIUM-HIGH: additive, but needing design alignment).

**Architecture-fit evaluation: the feature still fits.** Its backend dependencies (`TextEmotionParser`, `emotional_mapping.EmotionalState` / `get_parameters_for_state`) exist in current main with exactly the signatures the service calls (verified by execution, not just inspection). No competing `/parse-text` endpoint exists, and the PR #210 python agent (`agent/`) is unrelated. The one real misfit — the archived commit **replaced** the NavRail console shell — is resolved by integrating additively instead (see below).

## What's in the port (3 phases, TDD)

1. **`music_brain/nlp/`** — `KeywordExtractor` (200+ musical terms → taxonomy node hints) and `TextToIntentService` (keyword extraction → emotion parse → context-cluster matching → distribution blending). 17 new unit tests written first (`tests/unit/test_nlp_text_to_intent.py`), including the flagship behavior: "dorian" yields ~160 BPM in a metal context and ~72 BPM in a slow-blues context.
2. **`POST /parse-text`** — rewritten to current `api.py` conventions (`@api_error_handler`, `Field(..., max_length=4096)`, model beside endpoint). 5 endpoint tests (`tests/unit/test_api_parse_text.py`).
3. **Frontend** — `src/components/UniversalMusicInput/` (11 components), `src/data/{taxonomyTree,contextClusters,interpretationEngine}.ts`, `useTextParse` hook (debounce + abort + offline keyword fallback), `Interpretation` types, namespaced `umi-*` CSS (all 22 design tokens it uses verified present). `useMusicBrain` gains `parseText()` (bypasses the `USE_EXTERNAL_API` gate by design — local endpoint with client-side fallback).

## Deliberate deviations from the archive

- **UI mounts as a new 'Universal Input' 5th NavRail mode** instead of the archive's wholesale shell replacement. The archived `App.tsx`/`console-shell.css` layout rewrites are not ported. The new mode also appears automatically in the #211 rotary selector (it consumes the same `NAV_ITEMS`).
- **Cluster blend order fixed**: the archived `_merge_distributions` applied overrides strongest-first, letting a weaker cluster override a stronger one (e.g. post-rock at 0.667 dragged a metal-shred 1.0 tempo from 160 → ~117). Overrides now apply weakest-first so the highest-scored cluster has the final say — matching the feature's own documented intent. Caught by the tests-first port.
- **`tests/unit/interpretationEngine.test.ts` not ported** — it needs vitest, and the repo has no TS test runner (tsconfig only typechecks `src/`). Follow-up candidate.
- Lint fixes to meet current gates (unused imports/variables, black/ruff/flake8 at 100 cols).

## Verification

- `python3 -m pytest tests/` — **891 passed, 55 skipped, 0 failed** (22 tests added by this PR)
- `flake8 music_brain/ tests/ --max-line-length=100 --extend-ignore=E203,W503` — clean; `ruff check music_brain tests` — clean; `black --check --line-length=100` — clean on all touched files
- `npx tsc --noEmit` and `npm run build` — clean
- **Live round trip**: vite + uvicorn, typed "slow bluesy dorian, clean tone, laid back" → `POST /parse-text 200` → Slow Blues cluster chip (100%), keyword tags, mode-weight bars, ~64–80 BPM range, taxonomy-node highlight badges; taxonomy tree expands; other 4 modes unaffected.

Pre-existing note (not this PR): `scripts/{prepare_gigamidi_expressive,run_local_training_tui,vertex_dispatch_fma}.py` from #211 fail the strict `flake8 ... scripts/*.py` gate variant — flagged for a separate lint-fix task.

## Follow-ups (not blocking)

- Add vitest and port the archived `interpretationEngine` unit tests
- `KeywordExtractor` vocabulary gap: some cluster trigger words (e.g. "shred") aren't in the extraction vocabulary, so they can't contribute to cluster scores
- Optional: wire Generate in the UMI panel to surface generation results in the session bar

**Do not merge without explicit approval.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large additive surface (new API + big UI/data layer) affecting music generation intent mapping; behavior is mostly isolated to the new mode but `/parse-text` accepts free text with optional `user_id`.
> 
> **Overview**
> Adds **Universal Music Input** as a fifth console mode: a dual-pane UI where users browse a musical **taxonomy tree** (search, pin, manual toggles) alongside **natural-language** descriptions, with live feedback from interpretation results and a summary bar that drives **Generate** via existing `useMusicBrain` / intent payloads.
> 
> On the **backend**, introduces `music_brain/nlp/` (`KeywordExtractor`, `TextToIntentService`) and **`POST /parse-text`**, which returns probabilistic **param distributions**, **context clusters**, taxonomy activations, and confidence—optionally layered on emotion parsing when those deps are present. Cluster overrides are merged **weakest-first** so the top-scoring cluster wins on conflicts (fix vs. the archived behavior).
> 
> On the **frontend**, `useTextParse` debounces calls to `parseText()` (always hits the local API, with a small offline keyword fallback), plus shared data (`taxonomyTree`, `contextClusters`, `interpretationEngine`—the latter not wired into the main UMI flow yet). **Interpretive** slider state is UI-only for now. Unit tests cover NLP/API behavior (including context-dependent “dorian” tempo).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c966eee8045d67bf88684ed51fb5e8a7eb01c32b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->