### PR TITLE
fix(lint): clear flake8/black violations in FMA training scripts from #211

### DIFF
--- a/scripts/prepare_gigamidi_expressive.py
+++ b/scripts/prepare_gigamidi_expressive.py
@@ -76,7 +76,10 @@ def check_auth() -> tuple[bool, str]:
         info = whoami(token=token) if token else whoami()
         return True, f"logged in as {info.get('name', '?')}"
     except Exception as e:
-        return False, f"not logged in ({e.__class__.__name__}). Run `hf auth login` or export HUGGINGFACE_HUB_TOKEN."
+        return False, (
+            f"not logged in ({e.__class__.__name__}). "
+            "Run `hf auth login` or export HUGGINGFACE_HUB_TOKEN."
+        )
 
 
 def check_deps() -> list[str]:
@@ -91,6 +94,7 @@ def check_deps() -> list[str]:
 
 def probe_repo() -> dict:
     from huggingface_hub import HfApi
+
     api = HfApi()
     tree = api.list_repo_tree(REPO_ID, repo_type="dataset", recursive=True, path_in_repo=CONFIG)
     per_split: dict[str, dict] = {}
@@ -146,12 +150,15 @@ def cmd_dry_run(args: argparse.Namespace) -> int:
 
     target_bytes = splits.get(args.split, {}).get("bytes", 0)
     print()
-    print(f"On --download, {args.split} will cache ~{bytes_human(target_bytes)} of parquet to {HF_CACHE}.")
+    print(
+        f"On --download, {args.split} will cache "
+        f"~{bytes_human(target_bytes)} of parquet to {HF_CACHE}."
+    )
     print("Filter is applied in-memory after the parquet shards are in cache;")
     print("it does NOT reduce network transfer (all rows must be read to evaluate).")
     print()
     print("Next steps:")
-    print(f"  1. Ensure auth: `hf auth login` (token from https://hf.co/settings/tokens).")
+    print("  1. Ensure auth: `hf auth login` (token from https://hf.co/settings/tokens).")
     print(f"  2. Accept the dataset terms at https://hf.co/datasets/{REPO_ID} if not done.")
     print(f"  3. Run: python3 {Path(__file__).resolve()} --download")
     print(f"  4. Optional: add --extract to dump filtered MIDI bytes to {OUT_DIR}.")
@@ -177,14 +184,16 @@ def cmd_download(args: argparse.Namespace) -> int:
 
     thr = args.threshold
     expressive = ds.filter(lambda x: (x.get("nomml_score") or 0) > thr)
-    print(f"  expressive (nomml_score > {thr}):  {len(expressive):,} rows "
-          f"({100 * len(expressive) / max(len(ds), 1):.1f}% of split)")
+    print(
+        f"  expressive (nomml_score > {thr}):  {len(expressive):,} rows "
+        f"({100 * len(expressive) / max(len(ds), 1):.1f}% of split)"
+    )
 
     if args.extract:
         return _extract(expressive, args)
 
     print()
-    print(f"Done (parquet cached, subset materialised).")
+    print("Done (parquet cached, subset materialised).")
     print(f"Pass --extract to write per-row MIDI bytes to {OUT_DIR}.")
     return 0
 
@@ -197,7 +206,11 @@ def _extract(expressive, args: argparse.Namespace) -> int:
     candidates = [c for c in expressive.column_names if c in ("bytes", "midi", "audio", "data")]
     midi_col = candidates[0] if candidates else None
     if midi_col is None:
-        print("ERROR: could not locate a MIDI bytes column. Columns were:", expressive.column_names, file=sys.stderr)
+        print(
+            "ERROR: could not locate a MIDI bytes column. Columns were:",
+            expressive.column_names,
+            file=sys.stderr,
+        )
         return 2
     print(f"Extracting column `{midi_col}` to {OUT_DIR} ...")
 
@@ -220,16 +233,27 @@ def _extract(expressive, args: argparse.Namespace) -> int:
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    p.add_argument("--download", action="store_true",
-                   help="Actually download parquet shards and materialise the filter "
-                        "(NOT run by default).")
-    p.add_argument("--extract", action="store_true",
-                   help="After downloading, extract per-row MIDI bytes to OUT_DIR. "
-                        "Ignored without --download.")
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument(
+        "--download",
+        action="store_true",
+        help="Actually download parquet shards and materialise the filter " "(NOT run by default).",
+    )
+    p.add_argument(
+        "--extract",
+        action="store_true",
+        help="After downloading, extract per-row MIDI bytes to OUT_DIR. "
+        "Ignored without --download.",
+    )
     p.add_argument("--split", default=DEFAULT_SPLIT, choices=["train", "validation", "test"])
-    p.add_argument("--threshold", type=float, default=DEFAULT_THRESHOLD,
-                   help="nomml_score > THRESHOLD (default 0.5).")
+    p.add_argument(
+        "--threshold",
+        type=float,
+        default=DEFAULT_THRESHOLD,
+        help="nomml_score > THRESHOLD (default 0.5).",
+    )
     return p.parse_args(argv)
 
 

--- a/scripts/run_local_training_tui.py
+++ b/scripts/run_local_training_tui.py
@@ -5,7 +5,8 @@ Runs in iTerm2, WezTerm, or any terminal with color support.
 
 Usage:
   python scripts/run_local_training_tui.py --config config/jepa_training_local_mac.yaml
-  python scripts/run_local_training_tui.py --config config/jepa_training_local_mac.yaml --model chord_jepa
+  python scripts/run_local_training_tui.py --config config/jepa_training_local_mac.yaml \\
+      --model chord_jepa
 
 Requires: pip install rich
 """
@@ -35,6 +36,7 @@ except ImportError:
 
 def _load_config(path: str):
     import yaml
+
     with open(path) as f:
         return yaml.safe_load(f)
 
@@ -45,6 +47,7 @@ def _build_training_config(raw: dict):
         ChordJEPAConfig,
         TrainingConfig,
     )
+
     t = raw.get("training", {})
     training = TrainingConfig(
         epochs=int(t.get("epochs", 120)),
@@ -83,7 +86,6 @@ def _build_training_config(raw: dict):
 
 def make_render(state: dict, theme: Theme):
     """Build the Rich layout: header, progress, speed, model uniqueness, loss table."""
-    console = Console(theme=theme)
     model_name = state.get("model_name", "—")
     epoch = state.get("epoch", 0)
     total_epochs = state.get("total_epochs", 1)
@@ -136,6 +138,7 @@ def make_render(state: dict, theme: Theme):
     )
     metrics_panel = Panel(metrics, title="[bold]Metrics[/]", border_style="green")
     from rich.columns import Columns
+
     grid = Columns([progress_panel, metrics_panel], equal=False, expand=True)
     return Panel(
         header,
@@ -147,8 +150,13 @@ def make_render(state: dict, theme: Theme):
 
 def main():
     import argparse
+
     parser = argparse.ArgumentParser(description="Local JEPA training with Rich TUI")
-    parser.add_argument("--config", default=str(_REPO_ROOT / "config" / "jepa_training_local_mac.yaml"), help="Config YAML")
+    parser.add_argument(
+        "--config",
+        default=str(_REPO_ROOT / "config" / "jepa_training_local_mac.yaml"),
+        help="Config YAML",
+    )
     parser.add_argument("--model", choices=["audio_jepa", "chord_jepa", "both"], default="both")
     parser.add_argument("--epochs", type=int, default=None)
     args = parser.parse_args()
@@ -217,10 +225,23 @@ def main():
                     if len(dataset) == 0:
                         console.print(f"[red]ERROR:[/] No audio files in {audio_dir}")
                         continue
-                    loader = DataLoader(dataset, batch_size=training.batch_size, shuffle=True, num_workers=0)
+                    loader = DataLoader(
+                        dataset, batch_size=training.batch_size, shuffle=True, num_workers=0
+                    )
                     ckpt_dir = os.path.join(checkpoint_root, "audio_jepa")
-                    export_path = os.path.join(checkpoint_root, "audio_jepa.onnx") if raw.get("checkpoints", {}).get("export_onnx", True) else None
-                    train_audio_jepa(loader, audio_config, training, checkpoint_dir=ckpt_dir, export_path=export_path, progress_callback=progress_callback)
+                    export_path = (
+                        os.path.join(checkpoint_root, "audio_jepa.onnx")
+                        if raw.get("checkpoints", {}).get("export_onnx", True)
+                        else None
+                    )
+                    train_audio_jepa(
+                        loader,
+                        audio_config,
+                        training,
+                        checkpoint_dir=ckpt_dir,
+                        export_path=export_path,
+                        progress_callback=progress_callback,
+                    )
                 else:
                     midi_files = _midi_files(midi_dir) if os.path.isdir(midi_dir) else []
                     dataset = ChordSequenceDataset(
@@ -229,9 +250,17 @@ def main():
                         num_chords=chord_config.num_chords,
                         num_samples=256 if not midi_files else None,
                     )
-                    loader = DataLoader(dataset, batch_size=training.batch_size, shuffle=True, num_workers=0)
+                    loader = DataLoader(
+                        dataset, batch_size=training.batch_size, shuffle=True, num_workers=0
+                    )
                     ckpt_dir = os.path.join(checkpoint_root, "chord_jepa")
-                    train_chord_jepa(loader, chord_config, training, checkpoint_dir=ckpt_dir, progress_callback=progress_callback)
+                    train_chord_jepa(
+                        loader,
+                        chord_config,
+                        training,
+                        checkpoint_dir=ckpt_dir,
+                        progress_callback=progress_callback,
+                    )
         except Exception as e:
             exception_holder.append(e)
 
@@ -248,6 +277,7 @@ def main():
         train_thread.start()
         while train_thread.is_alive():
             import time
+
             live.update(make_render(state, theme))
             time.sleep(refresh_interval)
         live.update(make_render(state, theme))

--- a/scripts/vertex_dispatch_fma.py
+++ b/scripts/vertex_dispatch_fma.py
@@ -26,14 +26,11 @@ import logging
 import shutil
 import subprocess
 import sys
-import tarfile
 import tempfile
-import time
 from datetime import datetime
 from pathlib import Path
 
-logging.basicConfig(level=logging.INFO,
-                    format="%(asctime)s %(levelname)s: %(message)s")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
 logger = logging.getLogger("vertex_dispatch_fma")
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -46,9 +43,16 @@ TASK_CONFIGS = {
     # (audioread's ffmpeg subprocess is CPU-heavy).
     "genre": {
         "script": "training/scripts/train_fma_genre.py",
-        "extra_args": ["--epochs", "30", "--batch-size", "32",
-                       "--patience", "6", "--vertex",
-                       "--no-balanced-sampler"],
+        "extra_args": [
+            "--epochs",
+            "30",
+            "--batch-size",
+            "32",
+            "--patience",
+            "6",
+            "--vertex",
+            "--no-balanced-sampler",
+        ],
         "machine_type": "n1-standard-8",
         "accelerator_type": "NVIDIA_TESLA_T4",
         "accelerator_count": 1,
@@ -56,11 +60,18 @@ TASK_CONFIGS = {
     },
     "subgenre": {
         "script": "training/scripts/train_fma_subgenre.py",
-        "extra_args": ["--epochs", "40", "--batch-size", "32",
-                       "--patience", "8", "--vertex",
-                       "--no-balanced-sampler",
-                       "--init-from",
-                       "/gcs/kmidi-train-us-central1/runs/fma-genre-20260424-123839/model/best.pt"],
+        "extra_args": [
+            "--epochs",
+            "40",
+            "--batch-size",
+            "32",
+            "--patience",
+            "8",
+            "--vertex",
+            "--no-balanced-sampler",
+            "--init-from",
+            "/gcs/kmidi-train-us-central1/runs/fma-genre-20260424-123839/model/best.pt",
+        ],
         "machine_type": "n1-standard-8",
         "accelerator_type": "NVIDIA_TESLA_T4",
         "accelerator_count": 1,
@@ -68,10 +79,17 @@ TASK_CONFIGS = {
     },
     "tags": {
         "script": "training/scripts/train_fma_tags.py",
-        "extra_args": ["--epochs", "40", "--batch-size", "32",
-                       "--patience", "8", "--vertex",
-                       "--init-from",
-                       "/gcs/kmidi-train-us-central1/runs/fma-genre-20260424-123839/model/best.pt"],
+        "extra_args": [
+            "--epochs",
+            "40",
+            "--batch-size",
+            "32",
+            "--patience",
+            "8",
+            "--vertex",
+            "--init-from",
+            "/gcs/kmidi-train-us-central1/runs/fma-genre-20260424-123839/model/best.pt",
+        ],
         "machine_type": "n1-standard-8",
         "accelerator_type": "NVIDIA_TESLA_T4",
         "accelerator_count": 1,
@@ -107,7 +125,7 @@ TASK_CONFIGS = {
 }
 
 
-SETUP_PY = '''\
+SETUP_PY = """\
 from setuptools import setup, find_packages
 
 setup(
@@ -127,7 +145,7 @@ setup(
         "PyYAML",
     ],
 )
-'''
+"""
 
 
 def build_source_tarball() -> Path:
@@ -163,7 +181,10 @@ def build_source_tarball() -> Path:
     # Build sdist via `python setup.py sdist`
     subprocess.run(
         [sys.executable, "setup.py", "sdist", "--dist-dir", str(tmp)],
-        cwd=str(pkg), check=True, capture_output=True)
+        cwd=str(pkg),
+        check=True,
+        capture_output=True,
+    )
     dist_files = list(tmp.glob("*.tar.gz"))
     if not dist_files:
         raise RuntimeError("setup.py sdist produced no .tar.gz")
@@ -175,9 +196,7 @@ def build_source_tarball() -> Path:
 def upload_tarball(tar_path: Path, bucket: str) -> str:
     """Upload tarball to gs://bucket/vertex-packages/ and return gs:// URI."""
     uri = f"gs://{bucket}/vertex-packages/{tar_path.name}"
-    subprocess.run(
-        ["gcloud", "storage", "cp", str(tar_path), uri],
-        check=True, capture_output=True)
+    subprocess.run(["gcloud", "storage", "cp", str(tar_path), uri], check=True, capture_output=True)
     logger.info("Uploaded package → %s", uri)
     return uri
 
@@ -187,6 +206,7 @@ def submit_job(args: argparse.Namespace, package_uri: str, run_name: str) -> Non
     CLI accepts spot/preemptible GPUs (which the high-level aiplatform SDK
     doesn't expose cleanly) and supports baseOutputDirectory via --config."""
     import yaml
+
     cfg = TASK_CONFIGS[args.task]
 
     # Manifest paths contain /fma_medium/fma_medium/ (FMA tarball nests a
@@ -197,10 +217,14 @@ def submit_job(args: argparse.Namespace, package_uri: str, run_name: str) -> Non
 
     mel_cache_gcs = f"/gcs/{args.bucket}/fma/mel_cache"
     script_args = [
-        "--manifest", manifest_gcs,
-        "--gcs-audio-prefix", gcs_audio_prefix,
-        "--name", run_name,
-        "--num-workers", str(cfg.get("num_workers", 4)),
+        "--manifest",
+        manifest_gcs,
+        "--gcs-audio-prefix",
+        gcs_audio_prefix,
+        "--name",
+        run_name,
+        "--num-workers",
+        str(cfg.get("num_workers", 4)),
     ] + cfg["extra_args"]
     # Pass mel cache to training jobs (skip for the cache-builder itself
     # and the probe, which don't need or want it).
@@ -225,16 +249,18 @@ def submit_job(args: argparse.Namespace, package_uri: str, run_name: str) -> Non
         executor_image = "us-docker.pkg.dev/vertex-ai/training/sklearn-cpu.1-0:latest"
 
     spec = {
-        "workerPoolSpecs": [{
-            "machineSpec": machine_spec,
-            "replicaCount": 1,
-            "pythonPackageSpec": {
-                "executorImageUri": executor_image,
-                "packageUris": [package_uri],
-                "pythonModule": module_name,
-                "args": script_args,
-            },
-        }],
+        "workerPoolSpecs": [
+            {
+                "machineSpec": machine_spec,
+                "replicaCount": 1,
+                "pythonPackageSpec": {
+                    "executorImageUri": executor_image,
+                    "packageUris": [package_uri],
+                    "pythonModule": module_name,
+                    "args": script_args,
+                },
+            }
+        ],
         "baseOutputDirectory": {"outputUriPrefix": base_output_dir},
     }
     if args.spot:
@@ -244,7 +270,10 @@ def submit_job(args: argparse.Namespace, package_uri: str, run_name: str) -> Non
     cfg_path.write_text(yaml.safe_dump(spec, sort_keys=False))
 
     cmd = [
-        "gcloud", "ai", "custom-jobs", "create",
+        "gcloud",
+        "ai",
+        "custom-jobs",
+        "create",
         f"--project={args.project}",
         f"--region={args.region}",
         f"--display-name={run_name}",
@@ -253,9 +282,14 @@ def submit_job(args: argparse.Namespace, package_uri: str, run_name: str) -> Non
     if args.service_account:
         cmd.append(f"--service-account={args.service_account}")
 
-    logger.info("Submitting %s | machine=%s+%s×%d | spot=%s",
-                run_name, cfg["machine_type"], cfg["accelerator_type"],
-                cfg["accelerator_count"], args.spot)
+    logger.info(
+        "Submitting %s | machine=%s+%s×%d | spot=%s",
+        run_name,
+        cfg["machine_type"],
+        cfg["accelerator_type"],
+        cfg["accelerator_count"],
+        args.spot,
+    )
     logger.info("Output dir: %s", base_output_dir)
     logger.info("Config: %s", cfg_path)
 
@@ -277,20 +311,33 @@ def main() -> int:
     ap.add_argument("--project", default="devvy-490312")
     ap.add_argument("--region", default="us-central1")
     ap.add_argument("--bucket", default="kmidi-train-us-central1")
-    ap.add_argument("--service-account", default=None,
-                    help="Optional SA email. Default uses Compute Engine default SA.")
-    ap.add_argument("--manifest-name", default="fma_medium_manifest.csv",
-                    help="Filename under gs://<bucket>/fma/manifest/")
-    ap.add_argument("--spot", action="store_true", default=True,
-                    help="Use spot/preemptible VMs (default, required for T4 on free quota)")
+    ap.add_argument(
+        "--service-account",
+        default=None,
+        help="Optional SA email. Default uses Compute Engine default SA.",
+    )
+    ap.add_argument(
+        "--manifest-name",
+        default="fma_medium_manifest.csv",
+        help="Filename under gs://<bucket>/fma/manifest/",
+    )
+    ap.add_argument(
+        "--spot",
+        action="store_true",
+        default=True,
+        help="Use spot/preemptible VMs (default, required for T4 on free quota)",
+    )
     ap.add_argument("--no-spot", dest="spot", action="store_false")
-    ap.add_argument("--use-mel-cache", action="store_true", default=True,
-                    help="Pass --mel-cache-root=/gcs/<bucket>/fma/mel_cache to "
-                         "training jobs (skip audio decode when cache exists).")
+    ap.add_argument(
+        "--use-mel-cache",
+        action="store_true",
+        default=True,
+        help="Pass --mel-cache-root=/gcs/<bucket>/fma/mel_cache to "
+        "training jobs (skip audio decode when cache exists).",
+    )
     ap.add_argument("--no-mel-cache", dest="use_mel_cache", action="store_false")
     ap.add_argument("--dry-run", action="store_true")
-    ap.add_argument("--name", default=None,
-                    help="Run name. Default: <task>-YYYYMMDD-HHMMSS")
+    ap.add_argument("--name", default=None, help="Run name. Default: <task>-YYYYMMDD-HHMMSS")
     args = ap.parse_args()
 
     run_name = args.name or f"fma-{args.task}-{datetime.now().strftime('%Y%m%d-%H%M%S')}"


### PR DESCRIPTION
## Summary

PR #211 (06cdee03) added three training scripts with 16 flake8 violations that fail the strict lint gate in `.github/workflows/pr-review.yml`, and all three also failed `black --check --line-length=100` (black 25.12.0, the unpinned-latest version CI installs). This PR clears both gates.

- **scripts/prepare_gigamidi_expressive.py** — E501 x4 (wrapped; string contents byte-identical), F541 x2 (dropped the `f` prefix on placeholder-less strings)
- **scripts/run_local_training_tui.py** — E501 x7 (wrapped; the usage example in the docstring now uses a shell `\` continuation), F841 x1 (removed the unused `console` local in `make_render`; `main()` builds its own)
- **scripts/vertex_dispatch_fma.py** — F401 x2 (removed unused `tarfile` and `time` imports; the tarball is built via `setup.py sdist` in a subprocess and timestamps come from `datetime`)
- All three files normalized with `black --line-length=100` (25.12.0). That normalization is most of the diff volume in vertex_dispatch_fma.py (list/call rewrapping, `'''` -> `"""`) and is formatting-only.

No behavior change beyond the dead-code removals.

## Verification

- `flake8 music_brain/ tests/ scripts/*.py --max-line-length=100 --extend-ignore=E203,W503` -> exit 0 (16 violations before)
- `black --check --line-length=100` on the three files -> exit 0
- `python3 -m py_compile` on all three -> OK; `--help` smoke on prepare_gigamidi_expressive.py and vertex_dispatch_fma.py -> OK
- No tests import these scripts (grep over tests/ has zero hits); `python3 -m pytest tests/ --collect-only -q` -> 902 tests collected, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic lint/format and removal of unused imports/variables in standalone scripts; no changes to training or Vertex job logic.
> 
> **Overview**
> Brings **`scripts/prepare_gigamidi_expressive.py`**, **`scripts/run_local_training_tui.py`**, and **`scripts/vertex_dispatch_fma.py`** in line with the strict **`pr-review.yml`** gates (`flake8` at 100 columns and `black --check`).
> 
> **`prepare_gigamidi_expressive.py`** — wraps overlong lines (E501), drops pointless `f`-strings on static messages (F541), and reformats argparse/help text without changing wording.
> 
> **`run_local_training_tui.py`** — same E501/black wrapping for training calls and CLI; docstring usage example now uses a shell line continuation; removes an unused `Console` in `make_render` (F841) while `main()` still owns the live TUI console.
> 
> **`vertex_dispatch_fma.py`** — removes unused `tarfile` and `time` imports (F401); most of the diff is black reformatting (argument lists, `SETUP_PY` quotes, job YAML dict layout). Vertex packaging/submit behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d465c8683d86130404f008230bf355ce131ead1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->